### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ func main() {
 	ctx := context.Background()
 	topicId, postId := 1, 2
 	message := "Hello"
-	profile, resp, err := client.Messages.PostMessage(ctx, topicId, postId, message, nil)
+	profile, resp, err := client.Messages.PostMessage(ctx, topicId, message, nil)
 }
 ```
 


### PR DESCRIPTION
`client.Messages.PostMessage` doesn't have `postId` as argument.

https://github.com/nulab/go-typetalk/blob/1.1.0/typetalk/messages.go#L98