### PR TITLE
Support /api/v5/notifications/status

### DIFF
--- a/testdata/v5/get-notification-count.json
+++ b/testdata/v5/get-notification-count.json
@@ -1,0 +1,68 @@
+{
+    "statuses": [
+        {
+            "mySpace": {
+                "space": {
+                    "key": "xxxxxxxxx",
+                    "name": "Awesome Tech Inc.",
+                    "enabled": true,
+                    "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
+                },
+                "myRole": "ADMIN",
+                "isPaymentAdmin": true,
+                "invitableRoles": [
+                    "ADMIN",
+                    "USER",
+                    "GUEST"
+                ],
+                "myPlan": {
+                    "plan": {
+                        "key": "typetalk.standard10",
+                        "name": "Standard 10 Users",
+                        "limitNumberOfUsers": 10,
+                        "limitNumberOfAllowedAddresses": 10,
+                        "limitTotalAttachmentSize": 10737418240
+                    },
+                    "enabled": true,
+                    "trial": null,
+                    "numberOfUsers": 4,
+                    "numberOfAllowedAddresses": 0,
+                    "totalAttachmentSize": 14356,
+                    "createdAt": "2016-01-27T09:37:27Z",
+                    "updatedAt": "2018-09-10T02:24:16Z"
+                }
+            },
+            "access": {
+                "unopened": 1
+            },
+            "like": {
+                "receive": {
+                    "hasUnread": false,
+                    "readLikeId": 19811
+                }
+            },
+            "unreads": {
+                "topicIds": [
+                    4483
+                ],
+                "dmTopicIds": [
+                    6248
+                ]
+            }
+        }
+    ],
+    "notificationSettings": {
+        "favoriteTopicMobile": true,
+        "doNotDisturb": {
+            "isSuppressed": false,
+            "manual": {
+                "remainingTimeInMinutes": null
+            },
+            "scheduled": {
+                "enabled": true,
+                "start": "22:00",
+                "end": "07:00"
+            }
+        }
+    }
+}

--- a/typetalk/v5/notifications.go
+++ b/typetalk/v5/notifications.go
@@ -1,0 +1,98 @@
+package v5
+
+import (
+	"context"
+
+	"time"
+
+	. "github.com/nulab/go-typetalk/typetalk/shared"
+)
+
+type NotificationsService service
+
+type NotificationCount struct {
+	Statuses []*struct {
+		MySpace *MySpace `json:"mySpace"`
+		Access  *Access  `json:"access"`
+		Like    *struct {
+			Receive *struct {
+				HasUnread  bool `json:"hasUnread"`
+				ReadLikeID int  `json:"readLikeId"`
+			} `json:"receive"`
+		} `json:"like"`
+		Unreads *struct {
+			TopicIds   []int `json:"topicIds"`
+			DMTopicIds []int `json:"dmTopicIds"`
+		} `json:"unreads"`
+	} `json:"statuses"`
+	NotificationSettings *struct {
+		FavoriteTopicMobile bool          `json:"favoriteTopicMobile"`
+		DoNotDisturb        *DoNotDisturb `json:"doNotDisturb"`
+	} `json:"notificationSettings"`
+}
+
+type MySpace struct {
+	Space          *Space   `json:"space"`
+	MyRole         string   `json:"myRole"`
+	IsPaymentAdmin bool     `json:"isPaymentAdmin"`
+	InvitableRoles []string `json:"invitableRoles"`
+	MyPlan         MyPlan   `json:"myPlan"`
+}
+
+type Space struct {
+	Key      string `json:"key"`
+	Name     string `json:"name"`
+	Enabled  bool   `json:"enabled"`
+	ImageURL string `json:"imageUrl"`
+}
+
+type MyPlan struct {
+	Plan                     *Plan       `json:"plan"`
+	Enabled                  bool        `json:"enabled"`
+	Trial                    interface{} `json:"trial"`
+	NumberOfUsers            int         `json:"numberOfUsers"`
+	NumberOfAllowedAddresses int         `json:"numberOfAllowedAddresses"`
+	TotalAttachmentSize      int         `json:"totalAttachmentSize"`
+	CreatedAt                *time.Time  `json:"createdAt"`
+	UpdatedAt                *time.Time  `json:"updatedAt"`
+}
+
+type Access struct {
+	Unopened          int `json:"unopened"`
+	UnopenedExcludeDM int `json:"unopenedExcludeDM"`
+}
+
+type Plan struct {
+	Key                           string `json:"key"`
+	Name                          string `json:"name"`
+	LimitNumberOfUsers            int    `json:"limitNumberOfUsers"`
+	LimitNumberOfAllowedAddresses int    `json:"limitNumberOfAllowedAddresses"`
+	LimitTotalAttachmentSize      int    `json:"limitTotalAttachmentSize"`
+}
+
+type DoNotDisturb struct {
+	IsSuppressed bool       `json:"isSuppressed"`
+	Manual       *Manual    `json:"manual"`
+	Scheduled    *Scheduled `json:"scheduled"`
+}
+
+type Manual struct {
+	RemainingTimeInMinutes interface{} `json:"remainingTimeInMinutes"`
+}
+
+type Scheduled struct {
+	Enabled bool   `json:"enabled"`
+	Start   string `json:"start"`
+	End     string `json:"end"`
+}
+
+// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/5/get-notification-status/
+func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *Response, error) {
+	u := "notifications/status"
+	var result *NotificationCount
+	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+		return nil, resp, err
+	} else {
+		return result, resp, nil
+	}
+}

--- a/typetalk/v5/notifications_test.go
+++ b/typetalk/v5/notifications_test.go
@@ -1,0 +1,34 @@
+package v5
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
+	. "github.com/nulab/go-typetalk/typetalk/internal"
+)
+
+func Test_NotificationsService_GetNotificationCount_should_get_notification_count(t *testing.T) {
+	setup()
+	defer teardown()
+	b, _ := ioutil.ReadFile(fixturesPath + "get-notification-count.json")
+	mux.HandleFunc("/notifications/status",
+		func(w http.ResponseWriter, r *http.Request) {
+			TestMethod(t, r, "GET")
+			fmt.Fprint(w, string(b))
+		})
+
+	result, _, err := client.Notifications.GetNotificationCount(context.Background())
+	if err != nil {
+		t.Errorf("Returned error: %v", err)
+	}
+	var want *NotificationCount
+	json.Unmarshal(b, &want)
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("Returned result:\n result  %v,\n want %v", result, want)
+	}
+}

--- a/typetalk/v5/v5.go
+++ b/typetalk/v5/v5.go
@@ -1,0 +1,42 @@
+package v5
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/nulab/go-typetalk/typetalk/internal"
+)
+
+const (
+	ApiVersion = "v5"
+)
+
+type service struct {
+	client *internal.ClientCore
+}
+
+type Client struct {
+	client *internal.ClientCore
+
+	Notifications *NotificationsService
+}
+
+func (c *Client) SetTypetalkToken(token string) *Client {
+	c.client.TypetalkToken = token
+	return c
+}
+
+func NewClient(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	baseURL, _ := url.Parse(internal.DefaultBaseURL + ApiVersion + "/")
+
+	c := &Client{client: &internal.ClientCore{Client: httpClient, BaseURL: baseURL, UserAgent: internal.UserAgent}}
+
+	common := &service{client: c.client}
+
+	c.Notifications = (*NotificationsService)(common)
+
+	return c
+}

--- a/typetalk/v5/v5_test.go
+++ b/typetalk/v5/v5_test.go
@@ -1,0 +1,28 @@
+package v5
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+var (
+	mux    *http.ServeMux
+	client *Client
+	server *httptest.Server
+)
+
+const fixturesPath = "../../testdata/v5/"
+
+func setup() {
+	mux = http.NewServeMux()
+	server = httptest.NewServer(mux)
+
+	client = NewClient(nil)
+	parsedURL, _ := url.Parse(server.URL)
+	client.client.BaseURL = parsedURL
+}
+
+func teardown() {
+	server.Close()
+}


### PR DESCRIPTION
Added support for `/api/v5/notifications/status`
https://developer.nulab-inc.com/docs/typetalk/api/5/get-notification-status/

@vvatanabe  Could you review it?
