### PR TITLE
Declare Topic type in topics.go

### DIFF
--- a/typetalk/v1/talks.go
+++ b/typetalk/v1/talks.go
@@ -11,17 +11,6 @@ import (
 
 type TalksService service
 
-type Topic struct {
-	ID              int        `json:"id"`
-	Name            string     `json:"name"`
-	Description     string     `json:"description"`
-	Suggestion      string     `json:"suggestion"`
-	IsDirectMessage bool       `json:"isDirectMessage"`
-	LastPostedAt    *time.Time `json:"lastPostedAt"`
-	CreatedAt       *time.Time `json:"createdAt"`
-	UpdatedAt       *time.Time `json:"updatedAt"`
-}
-
 type Talk struct {
 	ID         int         `json:"id"`
 	TopicID    int         `json:"topicId"`

--- a/typetalk/v1/topics.go
+++ b/typetalk/v1/topics.go
@@ -11,6 +11,17 @@ import (
 
 type TopicsService service
 
+type Topic struct {
+	ID              int        `json:"id"`
+	Name            string     `json:"name"`
+	Description     string     `json:"description"`
+	Suggestion      string     `json:"suggestion"`
+	IsDirectMessage bool       `json:"isDirectMessage"`
+	LastPostedAt    *time.Time `json:"lastPostedAt"`
+	CreatedAt       *time.Time `json:"createdAt"`
+	UpdatedAt       *time.Time `json:"updatedAt"`
+}
+
 type TopicDetails struct {
 	Topic   *Topic        `json:"topic"`
 	MySpace *Organization `json:"mySpace"`


### PR DESCRIPTION
@vvatanabe 
I think we should declare `Topic` in `topics.go`. What do you think about it?