### PR TITLE
Support "/v2/spaces/:spaceKey/messages/@:accountName"

### DIFF
--- a/testdata/v2/get-direct-messages.json
+++ b/testdata/v2/get-direct-messages.json
@@ -1,0 +1,85 @@
+{
+    "topic": {
+        "id": 70283,
+        "name": "jessica,ahorowitz",
+        "suggestion": "jessica,ahorowitz",
+        "isDirectMessage": true,
+        "lastPostedAt": "2018-11-20T11:54:28Z",
+        "createdAt": "2018-04-09T10:27:36Z",
+        "updatedAt": "2018-04-09T10:27:36Z"
+    },
+    "mySpace": {
+        "space": {
+            "key": "qwerty",
+            "name": "Nulab Inc.",
+            "enabled": true,
+            "imageUrl": "https://apps.nulab-inc.com/spaces/qwerty/photo/large"
+        },
+        "myRole": "USER",
+        "isPaymentAdmin": false,
+        "invitableRoles": [],
+        "myPlan": {
+            "plan": {
+                "key": "typetalk.standard10",
+                "name": "Standard 10 Users",
+                "limitNumberOfUsers": 10,
+                "limitNumberOfAllowedAddresses": 10,
+                "limitTotalAttachmentSize": 10737418240
+            },
+            "enabled": true,
+            "trial": null,
+            "numberOfUsers": 8,
+            "numberOfAllowedAddresses": 0,
+            "totalAttachmentSize": 14356,
+            "createdAt": "2016-01-05T09:21:53Z",
+            "updatedAt": "2018-11-21T12:47:06Z"
+        }
+    },
+    "directMessage": {
+        "account": {
+            "id": 123,
+            "name": "ahorowitz",
+            "fullName": "AHorowitz",
+            "suggestion": "AHorowitz",
+            "imageUrl": "https://typetalk.com/accounts/123/profile_image.png?t=1522114457218",
+            "isBot": false,
+            "createdAt": "2013-08-02T03:43:13Z",
+            "updatedAt": "2018-11-21T09:15:34Z"
+        },
+        "status": {
+            "presence": "away",
+            "web": null,
+            "mobile": null
+        }
+    },
+    "bookmark": {
+        "postId": 22695053,
+        "updatedAt": "2018-11-20T11:57:07Z"
+    },
+    "posts": [
+        {
+            "id": 22695053,
+            "topicId": 70283,
+            "replyTo": null,
+            "message": "test",
+            "account": {
+                "id": 456,
+                "name": "jessica",
+                "fullName": "Jessica",
+                "suggestion": "Jessica",
+                "imageUrl": "https://typetalk.com/accounts/456/profile_image.png?t=1524879783557",
+                "isBot": false,
+                "createdAt": "2017-09-01T01:55:05Z",
+                "updatedAt": "2018-11-21T12:48:48Z"
+            },
+            "mention": null,
+            "attachments": [],
+            "likes": [],
+            "talks": [],
+            "links": [],
+            "createdAt": "2018-04-09T10:27:36Z",
+            "updatedAt": "2018-04-09T10:27:36Z"
+        }
+    ],
+    "hasNext": false
+}

--- a/typetalk/v1/messages.go
+++ b/typetalk/v1/messages.go
@@ -193,7 +193,7 @@ type GetMessagesOptions struct {
 	Direction string `json:"direction,omitempty"`
 }
 
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-direct-messages
+// Deprecated: Use GetDirectMessages in github.com/nulab/go-typetalk/typetalk/v2
 func (s *MessagesService) GetDirectMessages(ctx context.Context, accountName string, opt *GetMessagesOptions) (*DirectMessages, *Response, error) {
 	u, err := AddQueries(fmt.Sprintf("messages/@%s", accountName), opt)
 	if err != nil {

--- a/typetalk/v2/messages.go
+++ b/typetalk/v2/messages.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"fmt"
 
 	"time"
 
@@ -10,6 +11,19 @@ import (
 )
 
 type MessagesService service
+
+type DirectMessages struct {
+	Topic         *Topic         `json:"topic"`
+	DirectMessage *DirectMessage `json:"directMessage"`
+	Bookmark      *Bookmark      `json:"bookmark"`
+	Posts         []*Post        `json:"posts"`
+	HasNext       bool           `json:"hasNext"`
+}
+
+type Bookmark struct {
+	PostID    int       `json:"postId"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
 
 type SearchMessagesResult struct {
 	Count     int     `json:"count"`
@@ -29,6 +43,26 @@ type searchMessagesOptions struct {
 	*SearchMessagesOptions
 	SpaceKey string `json:"spaceKey"`
 	Q        string `json:"q"`
+}
+
+type GetMessagesOptions struct {
+	Count     int    `json:"count,omitempty"`
+	From      int    `json:"from,omitempty"`
+	Direction string `json:"direction,omitempty"`
+}
+
+// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-direct-messages
+func (s *MessagesService) GetDirectMessages(ctx context.Context, spaceKey, accountName string, opt *GetMessagesOptions) (*DirectMessages, *Response, error) {
+	u, err := AddQueries(fmt.Sprintf("spaces/%s/messages/@%s", spaceKey, accountName), opt)
+	if err != nil {
+		return nil, nil, err
+	}
+	var result *DirectMessages
+	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+		return nil, resp, err
+	} else {
+		return result, resp, nil
+	}
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/search-messages/

--- a/typetalk/v2/messages_test.go
+++ b/typetalk/v2/messages_test.go
@@ -14,6 +14,33 @@ import (
 	. "github.com/nulab/go-typetalk/typetalk/internal"
 )
 
+func Test_MessagesService_GetDirectMessages_should_get_some_direct_messages(t *testing.T) {
+	setup()
+	defer teardown()
+	spaceKey := "qwerty"
+	accountName := "test"
+	b, _ := ioutil.ReadFile(fixturesPath + "get-direct-messages.json")
+	mux.HandleFunc(fmt.Sprintf("/spaces/%s/messages/@%s", spaceKey, accountName),
+		func(w http.ResponseWriter, r *http.Request) {
+			TestMethod(t, r, "GET")
+			TestQueryValues(t, r, Values{
+				"count":     10,
+				"from":      1,
+				"direction": "backward",
+			})
+			fmt.Fprint(w, string(b))
+		})
+
+	result, _, err := client.Messages.GetDirectMessages(context.Background(), spaceKey, accountName, &GetMessagesOptions{10, 1, "backward"})
+	if err != nil {
+		t.Errorf("Returned error: %v", err)
+	}
+	want := &DirectMessages{}
+	json.Unmarshal(b, want)
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("Returned result:\n result  %v,\n want %v", result, want)
+	}
+}
 func Test_MessagesService_SearchMessages_should_get_some_posts(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Added support for "GET /v2/spaces/:spaceKey/messages/@:accountName".
https://developer.nulab-inc.com/docs/typetalk/api/2/get-direct-messages/

Could you review it, please?