### PR TITLE
Removed unnecessary else

### DIFF
--- a/typetalk/internal/internal.go
+++ b/typetalk/internal/internal.go
@@ -43,11 +43,11 @@ func (c *ClientCore) NewRequest(method, urlStr string, body interface{}) (*http.
 
 	var buf io.Reader
 	if body != nil {
-		if values, err := StructToValues(body); err != nil {
+		values, err := StructToValues(body)
+		if err != nil {
 			return nil, err
-		} else {
-			buf = strings.NewReader(values.Encode())
 		}
+		buf = strings.NewReader(values.Encode())
 	}
 
 	req, err := http.NewRequest(method, u.String(), buf)
@@ -269,10 +269,10 @@ func AddQueries(s string, opt interface{}) (string, error) {
 		return s, err
 	}
 
-	if values, err := StructToValues(opt); err != nil {
+	values, err := StructToValues(opt)
+	if err != nil {
 		return s, err
-	} else {
-		u.RawQuery = values.Encode()
-		return u.String(), nil
 	}
+	u.RawQuery = values.Encode()
+	return u.String(), nil
 }

--- a/typetalk/v1/accounts.go
+++ b/typetalk/v1/accounts.go
@@ -61,22 +61,22 @@ type OnlineStatus struct {
 func (s *AccountsService) GetMyProfile(ctx context.Context) (*MyProfile, *Response, error) {
 	u := "profile"
 	var result *MyProfile
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-friend-profile
 func (s *AccountsService) GetFriendProfile(ctx context.Context, accountName string) (*Profile, *Response, error) {
 	u := fmt.Sprintf("profile/%s", accountName)
 	var result *Profile
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type GetMyFriendsOptions struct {
@@ -92,11 +92,11 @@ func (s *AccountsService) GetMyFriends(ctx context.Context, opt *GetMyFriendsOpt
 		return nil, nil, err
 	}
 	var result *Friends
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type searchAccountsOptions struct {
@@ -110,11 +110,11 @@ func (s *AccountsService) SearchAccounts(ctx context.Context, nameOrEmailAddress
 		return nil, nil, err
 	}
 	var result *Account
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type getOnlineStatusOptions struct {
@@ -128,9 +128,9 @@ func (s *AccountsService) GetOnlineStatus(ctx context.Context, accountIds ...int
 		return nil, nil, err
 	}
 	var result *OnlineStatus
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v1/files.go
+++ b/typetalk/v1/files.go
@@ -39,11 +39,11 @@ func (s *FilesService) UploadAttachmentFile(ctx context.Context, topicId int, fi
 	}
 
 	attachmentFile := &AttachmentFile{}
-	if resp, err := s.client.Do(ctx, req, attachmentFile); err != nil {
+	resp, err := s.client.Do(ctx, req, attachmentFile)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return attachmentFile, resp, nil
 	}
+	return attachmentFile, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/download-attachment
@@ -63,7 +63,6 @@ func (s *FilesService) DownloadAttachmentFile(ctx context.Context, topicId, post
 	if err := CheckResponse(resp); err != nil {
 		resp.Body.Close()
 		return nil, err
-	} else {
-		return resp.Body, nil
 	}
+	return resp.Body, nil
 }

--- a/typetalk/v1/likes.go
+++ b/typetalk/v1/likes.go
@@ -2,9 +2,10 @@ package v1
 
 import (
 	"context"
+	"time"
+
 	. "github.com/nulab/go-typetalk/typetalk/internal"
 	. "github.com/nulab/go-typetalk/typetalk/shared"
-	"time"
 )
 
 type LikesService service
@@ -47,11 +48,11 @@ func (s *LikesService) GetLikesReceive(ctx context.Context, opt *GetLikesOptions
 	var result *struct {
 		LikedPosts []*ReceiveLikedPost `json:"likedPosts"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.LikedPosts, resp, nil
 	}
+	return result.LikedPosts, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-give/
@@ -63,11 +64,11 @@ func (s *LikesService) GetLikesGive(ctx context.Context, opt *GetLikesOptions) (
 	var result *struct {
 		GiveLikedPost []*GiveLikedPost `json:"likedPosts"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.GiveLikedPost, resp, nil
 	}
+	return result.GiveLikedPost, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-discover/
@@ -79,11 +80,11 @@ func (s *LikesService) GetLikesDiscover(ctx context.Context, opt *GetLikesOption
 	var result *struct {
 		DiscoverLikedPost []*DiscoverLikedPost `json:"likedPosts"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.DiscoverLikedPost, resp, nil
 	}
+	return result.DiscoverLikedPost, resp, nil
 }
 
 type readReceivedLikesOptions struct {
@@ -104,9 +105,9 @@ func (s *LikesService) ReadReceivedLikes(ctx context.Context, likeId int) (*Read
 	u := "likes/receive/bookmark/save"
 
 	var result *ReadReceivedLikesResult
-	if resp, err := s.client.Post(ctx, u, &readReceivedLikesOptions{likeId}, result); err != nil {
+	resp, err := s.client.Post(ctx, u, &readReceivedLikesOptions{likeId}, result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v1/mentions.go
+++ b/typetalk/v1/mentions.go
@@ -23,11 +23,11 @@ func (s *MentionsService) ReadMention(ctx context.Context, mentionId int) (*Ment
 	var result *struct {
 		Mention Mention `json:"mention"`
 	}
-	if resp, err := s.client.Put(ctx, u, nil, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, nil, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return &result.Mention, resp, nil
 	}
+	return &result.Mention, resp, nil
 }
 
 type GetMentionListOptions struct {
@@ -44,9 +44,9 @@ func (s *MentionsService) GetMentionList(ctx context.Context, opt *GetMentionLis
 	var result *struct {
 		Mentions []*Mention `json:"mentions"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Mentions, resp, nil
 	}
+	return result.Mentions, resp, nil
 }

--- a/typetalk/v1/messages.go
+++ b/typetalk/v1/messages.go
@@ -105,11 +105,11 @@ func (s *MessagesService) PostMessage(ctx context.Context, topicId int, message 
 		opt = &PostMessageOptions{}
 	}
 	var result *PostedMessageResult
-	if resp, err := s.client.Post(ctx, u, &postMessageOptions{opt, message}, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, &postMessageOptions{opt, message}, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type updateMessageOptions struct {
@@ -120,44 +120,44 @@ type updateMessageOptions struct {
 func (s *MessagesService) UpdateMessage(ctx context.Context, topicId, postId int, message string) (*UpdatedMessageResult, *Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d", topicId, postId)
 	var result *UpdatedMessageResult
-	if resp, err := s.client.Put(ctx, u, &updateMessageOptions{Message: message}, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, &updateMessageOptions{Message: message}, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-message
 func (s *MessagesService) DeleteMessage(ctx context.Context, topicId, postId int) (*Post, *Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d", topicId, postId)
 	var result *Post
-	if resp, err := s.client.Delete(ctx, u, &result); err != nil {
+	resp, err := s.client.Delete(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-message
 func (s *MessagesService) GetMessage(ctx context.Context, topicId, postId int) (*Message, *Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d", topicId, postId)
 	var result *Message
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/favorite-topic
 func (s *MessagesService) LikeMessage(ctx context.Context, topicId, postId int) (*LikedMessageResult, *Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d/like", topicId, postId)
 	var result *LikedMessageResult
-	if resp, err := s.client.Post(ctx, u, nil, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, nil, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/unfavorite-topic
@@ -166,11 +166,11 @@ func (s *MessagesService) UnlikeMessage(ctx context.Context, topicId, postId int
 	var result *struct {
 		Like Like `json:"like"`
 	}
-	if resp, err := s.client.Delete(ctx, u, &result); err != nil {
+	resp, err := s.client.Delete(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return &result.Like, resp, nil
 	}
+	return &result.Like, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/post-direct-message
@@ -180,11 +180,11 @@ func (s *MessagesService) PostDirectMessage(ctx context.Context, accountName, me
 		opt = &PostMessageOptions{}
 	}
 	var result *PostedMessageResult
-	if resp, err := s.client.Post(ctx, u, &postMessageOptions{opt, message}, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, &postMessageOptions{opt, message}, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type GetMessagesOptions struct {
@@ -200,11 +200,11 @@ func (s *MessagesService) GetDirectMessages(ctx context.Context, accountName str
 		return nil, nil, err
 	}
 	var result *DirectMessages
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Deprecated: Use GetMyDirectMessageTopics in github.com/nulab/go-typetalk/typetalk/v2
@@ -213,9 +213,9 @@ func (s *MessagesService) GetMyDirectMessageTopics(ctx context.Context) ([]*Dire
 	var result *struct {
 		Topics []*DirectMessageTopic `json:"topics"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Topics, resp, nil
 	}
+	return result.Topics, resp, nil
 }

--- a/typetalk/v1/notifications.go
+++ b/typetalk/v1/notifications.go
@@ -47,22 +47,22 @@ type NotificationCount struct {
 func (s *NotificationsService) GetNotificationList(ctx context.Context) (*NotificationList, *Response, error) {
 	u := "notifications"
 	var result *NotificationList
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-notification-status
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *Response, error) {
 	u := "notifications/status"
 	var result *NotificationCount
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Deprecated: Use ReadNotification in github.com/nulab/go-typetalk/typetalk/v3
@@ -71,9 +71,9 @@ func (s *NotificationsService) ReadNotification(ctx context.Context) (*Access, *
 	var result *struct {
 		Access *Access `json:"access"`
 	}
-	if resp, err := s.client.Put(ctx, u, nil, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, nil, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Access, resp, nil
 	}
+	return result.Access, resp, nil
 }

--- a/typetalk/v1/organizations.go
+++ b/typetalk/v1/organizations.go
@@ -73,20 +73,20 @@ func (s *OrganizationsService) GetMyOrganizations(ctx context.Context, excludesG
 	var result *struct {
 		MySpaces []*Organization `json:"mySpaces"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.MySpaces, resp, nil
 	}
+	return result.MySpaces, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-space-members
 func (s *OrganizationsService) GetOrganizationMembers(ctx context.Context, spaceKey string) (*OrganizationMembers, *Response, error) {
 	u := fmt.Sprintf("spaces/%s/members", spaceKey)
 	var result *OrganizationMembers
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v1/talks.go
+++ b/typetalk/v1/talks.go
@@ -54,11 +54,11 @@ type CreateTalkOptions struct {
 func (s *TalksService) CreateTalk(ctx context.Context, topicId int, talkName string, postIds ...int) (*CreatedTalkResult, *Response, error) {
 	u := fmt.Sprintf("topics/%d/talks", topicId)
 	var result *CreatedTalkResult
-	if resp, err := s.client.Post(ctx, u, &CreateTalkOptions{talkName, postIds}, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, &CreateTalkOptions{talkName, postIds}, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type updateTalkOptions struct {
@@ -73,22 +73,22 @@ func (s *TalksService) UpdateTalk(ctx context.Context, topicId, talkId int, talk
 	}
 
 	var result *UpdatedTalkResult
-	if resp, err := s.client.Put(ctx, u, nil, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, nil, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-talk
 func (s *TalksService) DeleteTalk(ctx context.Context, topicId, talkId int) (*DeletedTalkResult, *Response, error) {
 	u := fmt.Sprintf("topics/%d/talks/%d", topicId, talkId)
 	var result *DeletedTalkResult
-	if resp, err := s.client.Delete(ctx, u, &result); err != nil {
+	resp, err := s.client.Delete(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-talks
@@ -97,11 +97,11 @@ func (s *TalksService) GetTalkList(ctx context.Context, topicId int) ([]*Talk, *
 	var result *struct {
 		Talks []*Talk `json:"talks"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Talks, resp, nil
 	}
+	return result.Talks, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-talk
@@ -111,11 +111,11 @@ func (s *TalksService) GetMessagesInTalk(ctx context.Context, topicId, talkId in
 		return nil, nil, err
 	}
 	var result *MessagesInTalk
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type addMessageToTalkOptions struct {
@@ -126,11 +126,11 @@ type addMessageToTalkOptions struct {
 func (s *TalksService) AddMessagesToTalk(ctx context.Context, topicId, talkId int, postIds ...int) (*MessagesInTalk, *Response, error) {
 	u := fmt.Sprintf("topics/%d/talks/%d/posts", topicId, talkId)
 	var result *MessagesInTalk
-	if resp, err := s.client.Post(ctx, u, &addMessageToTalkOptions{postIds}, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, &addMessageToTalkOptions{postIds}, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type removeMessagesFromTalkOptions addMessageToTalkOptions
@@ -142,9 +142,9 @@ func (s *TalksService) RemoveMessagesFromTalk(ctx context.Context, topicId, talk
 		return nil, nil, err
 	}
 	var result *RemovedMessagesResult
-	if resp, err := s.client.Delete(ctx, u, &result); err != nil {
+	resp, err := s.client.Delete(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v1/topics.go
+++ b/typetalk/v1/topics.go
@@ -74,11 +74,11 @@ type CreateTopicOptions struct {
 func (s *TopicsService) CreateTopic(ctx context.Context, opt *CreateTopicOptions) (*TopicDetails, *Response, error) {
 	u := "topics"
 	var result *TopicDetails
-	if resp, err := s.client.Post(ctx, u, opt, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, opt, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type UpdateTopicOptions struct {
@@ -90,33 +90,33 @@ type UpdateTopicOptions struct {
 func (s *TopicsService) UpdateTopic(ctx context.Context, topicId int, opt *UpdateTopicOptions) (*TopicDetails, *Response, error) {
 	u := fmt.Sprintf("topics/%d", topicId)
 	var result *TopicDetails
-	if resp, err := s.client.Put(ctx, u, opt, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, opt, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-topic
 func (s *TopicsService) DeleteTopic(ctx context.Context, topicId int) (*Topic, *Response, error) {
 	u := fmt.Sprintf("topics/%d", topicId)
 	var result *Topic
-	if resp, err := s.client.Delete(ctx, u, &result); err != nil {
+	resp, err := s.client.Delete(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-topic-details
 func (s *TopicsService) GetTopicDetails(ctx context.Context, topicId int) (*TopicDetails, *Response, error) {
 	u := fmt.Sprintf("topics/%d", topicId)
 	var result *TopicDetails
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type GetTopicMessagesOptions struct {
@@ -132,11 +132,11 @@ func (s *TopicsService) GetTopicMessages(ctx context.Context, topicId int, opt *
 		return nil, nil, err
 	}
 	var result *TopicMessages
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type UpdateTopicMembersOptions struct {
@@ -153,33 +153,33 @@ type UpdateTopicMembersOptions struct {
 func (s *TopicsService) UpdateTopicMembers(ctx context.Context, topicId int, opt *UpdateTopicMembersOptions) (*TopicDetails, *Response, error) {
 	u := fmt.Sprintf("topics/%d/members/update", topicId)
 	var result *TopicDetails
-	if resp, err := s.client.Post(ctx, u, opt, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, opt, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/favorite-topic
 func (s *TopicsService) FavoriteTopic(ctx context.Context, topicId int) (*FavoriteTopic, *Response, error) {
 	u := fmt.Sprintf("topics/%d/favorite", topicId)
 	var result *FavoriteTopic
-	if resp, err := s.client.Post(ctx, u, nil, &result); err != nil {
+	resp, err := s.client.Post(ctx, u, nil, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/unfavorite-topic
 func (s *TopicsService) UnfavoriteTopic(ctx context.Context, topicId int) (*FavoriteTopic, *Response, error) {
 	u := fmt.Sprintf("topics/%d/favorite", topicId)
 	var result *FavoriteTopic
-	if resp, err := s.client.Delete(ctx, u, &result); err != nil {
+	resp, err := s.client.Delete(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 type readMessagesInTopicOptions struct {
@@ -196,11 +196,11 @@ func (s *TopicsService) ReadMessagesInTopic(ctx context.Context, topicId, postId
 	var result *struct {
 		Unread *Unread `json:"unread"`
 	}
-	if resp, err := s.client.Put(ctx, u, nil, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, nil, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Unread, resp, nil
 	}
+	return result.Unread, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-topics
@@ -209,9 +209,9 @@ func (s *TopicsService) GetMyTopics(ctx context.Context) ([]*FavoriteTopicWithUn
 	var result *struct {
 		Topics []*FavoriteTopicWithUnread `json:"topics"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Topics, resp, nil
 	}
+	return result.Topics, resp, nil
 }

--- a/typetalk/v2/likes.go
+++ b/typetalk/v2/likes.go
@@ -105,11 +105,11 @@ func (s *LikesService) GetLikesReceive(ctx context.Context, spaceKey string, opt
 	var result *struct {
 		LikedPosts []*ReceiveLikedPost `json:"likedPosts"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.LikedPosts, resp, nil
 	}
+	return result.LikedPosts, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-give/
@@ -121,11 +121,11 @@ func (s *LikesService) GetLikesGive(ctx context.Context, spaceKey string, opt *G
 	var result *struct {
 		GiveLikedPost []*GiveLikedPost `json:"likedPosts"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.GiveLikedPost, resp, nil
 	}
+	return result.GiveLikedPost, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-discover/
@@ -137,11 +137,11 @@ func (s *LikesService) GetLikesDiscover(ctx context.Context, spaceKey string, op
 	var result *struct {
 		DiscoverLikedPost []*DiscoverLikedPost `json:"likedPosts"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.DiscoverLikedPost, resp, nil
 	}
+	return result.DiscoverLikedPost, resp, nil
 }
 
 type ReadReceivedLikesOptions struct {
@@ -166,9 +166,9 @@ type ReadReceivedLikesResult struct {
 func (s *LikesService) ReadReceivedLikes(ctx context.Context, spaceKey string, opt *ReadReceivedLikesOptions) (*ReadReceivedLikesResult, *Response, error) {
 	u := "likes/receive/bookmark/save"
 	var result *ReadReceivedLikesResult
-	if resp, err := s.client.Post(ctx, u, &readReceivedLikesOptions{ReadReceivedLikesOptions: opt, SpaceKey: spaceKey}, result); err != nil {
+	resp, err := s.client.Post(ctx, u, &readReceivedLikesOptions{ReadReceivedLikesOptions: opt, SpaceKey: spaceKey}, result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v2/mentions.go
+++ b/typetalk/v2/mentions.go
@@ -35,9 +35,9 @@ func (s *MentionsService) GetMentionList(ctx context.Context, spaceKey string, o
 	var result *struct {
 		Mentions []*Mention `json:"mentions"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Mentions, resp, nil
 	}
+	return result.Mentions, resp, nil
 }

--- a/typetalk/v2/messages.go
+++ b/typetalk/v2/messages.go
@@ -58,11 +58,11 @@ func (s *MessagesService) GetDirectMessages(ctx context.Context, spaceKey, accou
 		return nil, nil, err
 	}
 	var result *DirectMessages
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/search-messages/
@@ -72,9 +72,9 @@ func (s *MessagesService) SearchMessages(ctx context.Context, spaceKey, q string
 		return nil, nil, err
 	}
 	var result *SearchMessagesResult
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v2/notifications.go
+++ b/typetalk/v2/notifications.go
@@ -90,20 +90,20 @@ type Scheduled struct {
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *Response, error) {
 	u := "notifications/status"
 	var result *NotificationCount
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }
 
 // Deprecated: Use ReadNotification in github.com/nulab/go-typetalk/typetalk/v3
 func (s *NotificationsService) ReadNotification(ctx context.Context) (*ReadNotificationResult, *Response, error) {
 	u := "notifications"
 	var result *ReadNotificationResult
-	if resp, err := s.client.Put(ctx, u, nil, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, nil, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v2/topics.go
+++ b/typetalk/v2/topics.go
@@ -54,11 +54,11 @@ func (s *TopicsService) GetMyTopics(ctx context.Context, spaceKey string) ([]*Fa
 	var result *struct {
 		Topics []*FavoriteTopicWithUnread `json:"topics"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Topics, resp, nil
 	}
+	return result.Topics, resp, nil
 }
 
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-dm-topics
@@ -70,9 +70,9 @@ func (s *MessagesService) GetMyDirectMessageTopics(ctx context.Context, spaceKey
 	var result *struct {
 		DirectMessageTopics []*DirectMessageTopic `json:"topics"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.DirectMessageTopics, resp, nil
 	}
+	return result.DirectMessageTopics, resp, nil
 }

--- a/typetalk/v3/accounts.go
+++ b/typetalk/v3/accounts.go
@@ -41,9 +41,9 @@ func (s *AccountsService) GetMyFriends(ctx context.Context, spaceKey, q string, 
 	var result *struct {
 		Accounts []*Account `json:"accounts"`
 	}
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result.Accounts, resp, nil
 	}
+	return result.Accounts, resp, nil
 }

--- a/typetalk/v3/notifications.go
+++ b/typetalk/v3/notifications.go
@@ -32,9 +32,9 @@ type readNotificationOptions struct {
 func (s *NotificationsService) ReadNotification(ctx context.Context, spaceKey string) (*ReadNotificationResult, *Response, error) {
 	u := "notifications"
 	var result *ReadNotificationResult
-	if resp, err := s.client.Put(ctx, u, &readNotificationOptions{spaceKey}, &result); err != nil {
+	resp, err := s.client.Put(ctx, u, &readNotificationOptions{spaceKey}, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v4/accounts.go
+++ b/typetalk/v4/accounts.go
@@ -55,9 +55,9 @@ func (s *AccountsService) GetMyFriends(ctx context.Context, spaceKey, q string, 
 		return nil, nil, err
 	}
 	var result *Friends
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }

--- a/typetalk/v5/notifications.go
+++ b/typetalk/v5/notifications.go
@@ -90,9 +90,9 @@ type Scheduled struct {
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *Response, error) {
 	u := "notifications/status"
 	var result *NotificationCount
-	if resp, err := s.client.Get(ctx, u, &result); err != nil {
+	resp, err := s.client.Get(ctx, u, &result)
+	if err != nil {
 		return nil, resp, err
-	} else {
-		return result, resp, nil
 	}
+	return result, resp, nil
 }


### PR DESCRIPTION
Removed unnecessary else

https://golang.org/doc/effective_go.html
> In the Go libraries, you'll find that when an if statement doesn't flow into the next statement—that is, the body ends in break, continue, goto, or return—the unnecessary else is omitted. 

I guess it is recommended to reduce unnecessary `else`.
Could you review it, please? 🙏 