### PR TITLE
,Support /api/v2/spaces/:spaceKey/messages/@:accountName

### DIFF
--- a/testdata/v2/post-direct-message.json
+++ b/testdata/v2/post-direct-message.json
@@ -1,0 +1,56 @@
+{
+    "space": {
+        "key": "xxxxxxxx",
+        "name": "Awesome Tech Inc.",
+        "enabled": true,
+        "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxx/photo/large"
+    },
+    "topic": {
+        "id": 3917,
+        "name": "Jessica,StefHull",
+        "suggestion": "Jessica,StefHull",
+        "isDirectMessage": true,
+        "lastPostedAt": "2018-11-26T01:09:12Z",
+        "createdAt": "2016-07-06T02:51:03Z",
+        "updatedAt": "2016-08-17T08:30:58Z",
+        "description": ""
+    },
+    "post": {
+        "id": 168196,
+        "topicId": 3917,
+        "replyTo": null,
+        "message": "Sure!",
+        "contents": null,
+        "account": {
+            "id": 2500,
+            "name": "Jessica",
+            "fullName": "Jessica",
+            "suggestion": "Jessica",
+            "imageUrl": "https://typetalk.com/accounts/2500/profile_image.png?t=1454061730873",
+            "isBot": false,
+            "createdAt": "2016-01-27T09:55:35Z",
+            "updatedAt": "2018-11-26T01:07:27Z"
+        },
+        "mention": null,
+        "attachments": [],
+        "likes": [],
+        "talks": [],
+        "links": [],
+        "createdAt": "2018-11-26T01:09:12Z",
+        "updatedAt": "2018-11-26T01:09:12Z"
+    },
+    "mentions": [],
+    "exceedsAttachmentLimit": false,
+    "directMessage": {
+        "account": {
+            "id": 2498,
+            "name": "Stefanie",
+            "fullName": "Stefanie",
+            "suggestion": "Stefanie",
+            "imageUrl": "https://typetalk.com/accounts/2498/profile_image.png?t=1453891479138",
+            "isBot": false,
+            "createdAt": "2016-01-27T09:55:09Z",
+            "updatedAt": "2018-11-09T10:29:47Z"
+        }
+    }
+}

--- a/typetalk/v1/messages.go
+++ b/typetalk/v1/messages.go
@@ -173,7 +173,7 @@ func (s *MessagesService) UnlikeMessage(ctx context.Context, topicId, postId int
 	return &result.Like, resp, nil
 }
 
-// Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/post-direct-message
+// Deprecated: Use PostDirectMessage in github.com/nulab/go-typetalk/typetalk/v2
 func (s *MessagesService) PostDirectMessage(ctx context.Context, accountName, message string, opt *PostMessageOptions) (*PostedMessageResult, *Response, error) {
 	u := fmt.Sprintf("messages/@%s", accountName)
 	if opt == nil {

--- a/typetalk/v2/messages_test.go
+++ b/typetalk/v2/messages_test.go
@@ -41,6 +41,54 @@ func Test_MessagesService_GetDirectMessages_should_get_some_direct_messages(t *t
 		t.Errorf("Returned result:\n result  %v,\n want %v", result, want)
 	}
 }
+
+func Test_MessagesService_PostDirectMessage_should_post_dairect_message(t *testing.T) {
+	setup()
+	defer teardown()
+	spaceKey := "qwerty"
+	accountName := "test"
+	b, _ := ioutil.ReadFile(fixturesPath + "post-direct-message.json")
+	mux.HandleFunc(fmt.Sprintf("/spaces/%s/messages/@%s", spaceKey, accountName),
+		func(w http.ResponseWriter, r *http.Request) {
+			TestMethod(t, r, "POST")
+			TestFormValues(t, r, Values{
+				"message":                 "hello",
+				"replyTo":                 2,
+				"showLinkMeta":            true,
+				"fileKeys[0]":             "key0",
+				"fileKeys[1]":             "key1",
+				"fileKeys[2]":             "key2",
+				"talkIds[0]":              0,
+				"talkIds[1]":              1,
+				"talkIds[2]":              2,
+				"attachments[0].fileUrl":  "Url0",
+				"attachments[1].fileUrl":  "Url1",
+				"attachments[2].fileUrl":  "Url2",
+				"attachments[0].fileName": "Name0",
+				"attachments[1].fileName": "Name1",
+				"attachments[2].fileName": "Name2",
+			})
+			fmt.Fprint(w, string(b))
+		})
+
+	result, _, err := client.Messages.PostDirectMessage(context.Background(), spaceKey, accountName, "hello", &PostMessageOptions{
+		ReplyTo:      2,
+		ShowLinkMeta: true,
+		FileKeys:     []string{"key0", "key1", "key2"},
+		TalkIds:      []int{0, 1, 2},
+		FileUrls:     []string{"Url0", "Url1", "Url2"},
+		FileNames:    []string{"Name0", "Name1", "Name2"},
+	})
+	if err != nil {
+		t.Errorf("Returned error: %v", err)
+	}
+	want := &PostedMessageResult{}
+	json.Unmarshal(b, want)
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("Returned result:\n result  %v,\n want %v", result, want)
+	}
+}
+
 func Test_MessagesService_SearchMessages_should_get_some_posts(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
https://github.com/nulab/go-typetalk/issues/19

Support "/api/v2/spaces/:spaceKey/messages/@:accountName".
Could you review it, please? :pray: