### PR TITLE
Use const http.Method*

### DIFF
--- a/typetalk/internal/internal.go
+++ b/typetalk/internal/internal.go
@@ -199,7 +199,7 @@ func (c *ClientCore) Put(ctx context.Context, url string, body interface{}, v in
 }
 
 func (c *ClientCore) Delete(ctx context.Context, url string, v interface{}) (*shared.Response, error) {
-	return c.Call(ctx, "DELETE", url, nil, v)
+	return c.Call(ctx, http.MethodDelete, url, nil, v)
 }
 
 func (c *ClientCore) Get(ctx context.Context, url string, v interface{}) (*shared.Response, error) {

--- a/typetalk/internal/internal.go
+++ b/typetalk/internal/internal.go
@@ -203,7 +203,7 @@ func (c *ClientCore) Delete(ctx context.Context, url string, v interface{}) (*sh
 }
 
 func (c *ClientCore) Get(ctx context.Context, url string, v interface{}) (*shared.Response, error) {
-	return c.Call(ctx, "GET", url, nil, v)
+	return c.Call(ctx, http.MethodGet, url, nil, v)
 }
 
 func CheckResponse(r *http.Response) error {

--- a/typetalk/internal/internal.go
+++ b/typetalk/internal/internal.go
@@ -195,7 +195,7 @@ func (c *ClientCore) Post(ctx context.Context, url string, body interface{}, v i
 }
 
 func (c *ClientCore) Put(ctx context.Context, url string, body interface{}, v interface{}) (*shared.Response, error) {
-	return c.Call(ctx, "PUT", url, body, v)
+	return c.Call(ctx, http.MethodPut, url, body, v)
 }
 
 func (c *ClientCore) Delete(ctx context.Context, url string, v interface{}) (*shared.Response, error) {

--- a/typetalk/internal/internal.go
+++ b/typetalk/internal/internal.go
@@ -95,7 +95,7 @@ func (c *ClientCore) NewMultipartRequest(urlStr string, values map[string]io.Rea
 		return nil, err
 	}
 	resolvedURL := c.BaseURL.ResolveReference(rel)
-	req, err := http.NewRequest("POST", resolvedURL.String(), &buffer)
+	req, err := http.NewRequest(http.MethodPost, resolvedURL.String(), &buffer)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (c *ClientCore) NewUploadRequest(urlStr string, reader io.Reader, size int6
 	}
 
 	resolvedURL := c.BaseURL.ResolveReference(rel)
-	req, err := http.NewRequest("POST", resolvedURL.String(), reader)
+	req, err := http.NewRequest(http.MethodPost, resolvedURL.String(), reader)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (c *ClientCore) Call(ctx context.Context, method string, url string, body i
 }
 
 func (c *ClientCore) Post(ctx context.Context, url string, body interface{}, v interface{}) (*shared.Response, error) {
-	return c.Call(ctx, "POST", url, body, v)
+	return c.Call(ctx, http.MethodPost, url, body, v)
 }
 
 func (c *ClientCore) Put(ctx context.Context, url string, body interface{}, v interface{}) (*shared.Response, error) {

--- a/typetalk/v1/accounts_test.go
+++ b/typetalk/v1/accounts_test.go
@@ -17,7 +17,7 @@ func Test_AccountsService_GetMyProfile_should_get_a_profile(t *testing.T) {
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-profile.json")
 	mux.HandleFunc("/profile", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, string(b))
 	})
 
@@ -39,7 +39,7 @@ func Test_AccountsService_GetFriendProfile_should_get_a_profile(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-friend-profile.json")
 	accountName := "ahorowitz"
 	mux.HandleFunc(fmt.Sprintf("/profile/%s", accountName), func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, string(b))
 	})
 
@@ -60,7 +60,7 @@ func Test_AccountsService_GetMyFriends_should_get_some_friends(t *testing.T) {
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-friends.json")
 	mux.HandleFunc("/search/friends", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestQueryValues(t, r, Values{
 			"q":      "test",
 			"offset": 10,
@@ -90,7 +90,7 @@ func Test_AccountsService_SearchAccounts_should_get_some_accounts(t *testing.T) 
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "search-accounts.json")
 	mux.HandleFunc("/search/accounts", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestQueryValues(t, r, Values{
 			"nameOrEmailAddress": "test",
 		})
@@ -114,7 +114,7 @@ func Test_AccountsService_GetOnlineStatus_should_get_some_accounts_online_status
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "get-online-status.json")
 	mux.HandleFunc("/accounts/status", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestQueryValues(t, r, Values{
 			"accountIds[0]": 1,
 			"accountIds[1]": 2,

--- a/typetalk/v1/files.go
+++ b/typetalk/v1/files.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 
 	. "github.com/nulab/go-typetalk/typetalk/internal"
@@ -50,7 +51,7 @@ func (s *FilesService) UploadAttachmentFile(ctx context.Context, topicId int, fi
 func (s *FilesService) DownloadAttachmentFile(ctx context.Context, topicId, postId, attachmentId int, filename string) (io.ReadCloser, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d/attachments/%d/%s", topicId, postId, attachmentId, filename)
 
-	req, err := s.client.NewRequest("GET", u, nil)
+	req, err := s.client.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/typetalk/v1/files_test.go
+++ b/typetalk/v1/files_test.go
@@ -46,7 +46,7 @@ func Test_FilesService_DownloadAttachmentFile_should_download_an_attachment_file
 	filename := "sample.jpg"
 	b, _ := ioutil.ReadFile(fixturesPath + filename)
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/attachments/%d/%s", topicId, postId, attachmentId, filename), func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestHeader(t, r, "Accept", DefaultMediaType)
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Disposition", "attachment; filename="+filename)

--- a/typetalk/v1/files_test.go
+++ b/typetalk/v1/files_test.go
@@ -20,7 +20,7 @@ func Test_FilesService_UploadAttachmentFile_should_upload_an_attachment_file(t *
 	topicId := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "upload-attachment-file.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%v/attachments", topicId), func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "POST")
+		TestMethod(t, r, http.MethodPost)
 		fmt.Fprint(w, string(b))
 	})
 

--- a/typetalk/v1/likes_test.go
+++ b/typetalk/v1/likes_test.go
@@ -18,7 +18,7 @@ func Test_LikesService_GetLikesReceive_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-likes-receive.json")
 	mux.HandleFunc("/likes/receive",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"from": 1,
 			})
@@ -44,7 +44,7 @@ func Test_LikesService_GetLikesGive_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-likes-give.json")
 	mux.HandleFunc("/likes/give",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"from": 1,
 			})
@@ -70,7 +70,7 @@ func Test_LikesService_GetLikesDiscover_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-likes-discover.json")
 	mux.HandleFunc("/likes/discover",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"from": 1,
 			})

--- a/typetalk/v1/likes_test.go
+++ b/typetalk/v1/likes_test.go
@@ -96,7 +96,7 @@ func Test_LikesService_ReadReceivedLikes_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "read-received-likes.json")
 	mux.HandleFunc("/likes/receive/bookmark/save",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"likeId": 1,
 			})

--- a/typetalk/v1/mentions_test.go
+++ b/typetalk/v1/mentions_test.go
@@ -40,7 +40,7 @@ func Test_MentionsService_GetMentionList_should_get_some_mentions(t *testing.T) 
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "get-mention-list.json")
 	mux.HandleFunc("/mentions", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestQueryValues(t, r, Values{
 			"from":   10,
 			"unread": true,

--- a/typetalk/v1/mentions_test.go
+++ b/typetalk/v1/mentions_test.go
@@ -18,7 +18,7 @@ func Test_MentionsService_ReadMention_should_read_a_mention(t *testing.T) {
 	mentionId := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "read-mention.json")
 	mux.HandleFunc(fmt.Sprintf("/mentions/%d", mentionId), func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "PUT")
+		TestMethod(t, r, http.MethodPut)
 		fmt.Fprint(w, string(b))
 	})
 

--- a/typetalk/v1/messages_test.go
+++ b/typetalk/v1/messages_test.go
@@ -66,7 +66,7 @@ func Test_MessagesService_UpdateMessage_should_update_a_message(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "update-message.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicId, postId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "PUT")
+			TestMethod(t, r, http.MethodPut)
 			TestFormValues(t, r, Values{"message": message})
 			fmt.Fprint(w, string(b))
 		})

--- a/typetalk/v1/messages_test.go
+++ b/typetalk/v1/messages_test.go
@@ -113,7 +113,7 @@ func Test_MessagesService_GetMessage_should_get_a_message(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-message.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicId, postId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -227,7 +227,7 @@ func Test_MessagesService_GetDirectMessages_should_get_some_direct_messages(t *t
 	b, _ := ioutil.ReadFile(fixturesPath + "get-direct-messages.json")
 	mux.HandleFunc(fmt.Sprintf("/messages/@%s", accountName),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"count":     10,
 				"from":      1,
@@ -253,7 +253,7 @@ func Test_MessagesService_GetMyDirectMessageTopics_should_get_some_topics_of_dir
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-direct-message-topics.json")
 	mux.HandleFunc("/messages",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v1/messages_test.go
+++ b/typetalk/v1/messages_test.go
@@ -18,7 +18,7 @@ func Test_MessagesService_PostMessage_should_post_a_message(t *testing.T) {
 	topicId := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "post-message.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%v", topicId), func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "POST")
+		TestMethod(t, r, http.MethodPost)
 		TestFormValues(t, r, Values{
 			"message":                 "hello",
 			"replyTo":                 2,
@@ -136,7 +136,7 @@ func Test_MessagesService_LikeMessage_should_like_a_message(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "like-message.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/like", topicId, postId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -181,7 +181,7 @@ func Test_MessagesService_PostDirectMessage_should_post_dairect_message(t *testi
 	b, _ := ioutil.ReadFile(fixturesPath + "post-direct-message.json")
 	mux.HandleFunc(fmt.Sprintf("/messages/@%s", accountName),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"message":                 "hello",
 				"replyTo":                 2,

--- a/typetalk/v1/messages_test.go
+++ b/typetalk/v1/messages_test.go
@@ -90,7 +90,7 @@ func Test_MessagesService_DeleteMessage_should_delete_a_message(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "delete-message.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicId, postId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "DELETE")
+			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -159,7 +159,7 @@ func Test_MessagesService_UnikeMessage_should_unlike_a_message(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "unlike-message.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/like", topicId, postId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "DELETE")
+			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v1/notifications_test.go
+++ b/typetalk/v1/notifications_test.go
@@ -18,7 +18,7 @@ func Test_NotificationsService_GetNotificationList_should_get_some_notifications
 	b, _ := ioutil.ReadFile(fixturesPath + "get-notification-list.json")
 	mux.HandleFunc("/notifications",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -39,7 +39,7 @@ func Test_NotificationsService_GetNotificationCount_should_get_notification_coun
 	b, _ := ioutil.ReadFile(fixturesPath + "get-notification-count.json")
 	mux.HandleFunc("/notifications/status",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v1/notifications_test.go
+++ b/typetalk/v1/notifications_test.go
@@ -60,7 +60,7 @@ func Test_NotificationsService_ReadNotification_should_read_notification(t *test
 	b, _ := ioutil.ReadFile(fixturesPath + "read-notification.json")
 	mux.HandleFunc("/notifications",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "PUT")
+			TestMethod(t, r, http.MethodPut)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v1/organizations_test.go
+++ b/typetalk/v1/organizations_test.go
@@ -18,7 +18,7 @@ func Test_OrganizationsService_GetMyOrganizations_should_get_my_organizations(t 
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-organizations.json")
 	mux.HandleFunc("/spaces",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{"excludesGuest": true})
 			fmt.Fprint(w, string(b))
 		})
@@ -43,7 +43,7 @@ func Test_OrganizationsService_GetOrganizationMembers_should_get_some_organizati
 	b, _ := ioutil.ReadFile(fixturesPath + "get-organization-members.json")
 	mux.HandleFunc(fmt.Sprintf("/spaces/%s/members", spaceKey),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v1/talks_test.go
+++ b/typetalk/v1/talks_test.go
@@ -98,7 +98,7 @@ func Test_TalksService_GetTalkList_should_get_talk_list(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-talk-list.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -123,7 +123,7 @@ func Test_TalksService_GetMessagesInTalk_should_get_some_messages_in_talk(t *tes
 	b, _ := ioutil.ReadFile(fixturesPath + "get-messages-in-talk.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicId, talkId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"count":     10,
 				"from":      3,

--- a/typetalk/v1/talks_test.go
+++ b/typetalk/v1/talks_test.go
@@ -76,7 +76,7 @@ func Test_TalksService_DeleteTalk_should_delete_a_talk(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "update-talk.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d", topicId, talkId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "DELETE")
+			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -179,7 +179,7 @@ func Test_TalksService_RemoveMessagesFromTalk_should_remove_some_messages_from_t
 	b, _ := ioutil.ReadFile(fixturesPath + "remove-messages-from-talk.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicId, talkId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "DELETE")
+			TestMethod(t, r, http.MethodDelete)
 			TestQueryValues(t, r, Values{
 				"postIds[0]": 1,
 				"postIds[1]": 2,

--- a/typetalk/v1/talks_test.go
+++ b/typetalk/v1/talks_test.go
@@ -50,7 +50,7 @@ func Test_TalksService_UpdateTalk_should_update_a_talk_name(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "update-talk.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d", topicId, talkId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "PUT")
+			TestMethod(t, r, http.MethodPut)
 			TestQueryValues(t, r, Values{
 				"talkName": talkName,
 			})

--- a/typetalk/v1/talks_test.go
+++ b/typetalk/v1/talks_test.go
@@ -20,7 +20,7 @@ func Test_TalksService_CreateTalk_should_create_a_talk(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "create-talk.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"talkName":   talkName,
 				"postIds[0]": 1,
@@ -151,7 +151,7 @@ func Test_TalksService_AddMessageToTalk_should_add_some_messages_to_talk(t *test
 	b, _ := ioutil.ReadFile(fixturesPath + "add-messages-to-talk.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicId, talkId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"postIds[0]": 1,
 				"postIds[1]": 2,

--- a/typetalk/v1/topics_test.go
+++ b/typetalk/v1/topics_test.go
@@ -49,7 +49,7 @@ func Test_TopicsService_UpdateTopic_should_update_a_topic(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "update-topic.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "PUT")
+			TestMethod(t, r, http.MethodPut)
 			TestFormValues(t, r, Values{
 				"name":        "nulab",
 				"description": "This is a test topic.",
@@ -232,7 +232,7 @@ func Test_TopicsService_ReadMessagesInTopic_should_read_some_messages_in_topic(t
 	b, _ := ioutil.ReadFile(fixturesPath + "read-messages-in-topic.json")
 	mux.HandleFunc("/bookmarks",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "PUT")
+			TestMethod(t, r, http.MethodPut)
 			TestQueryValues(t, r, Values{
 				"topicId": 1,
 				"postId":  1,

--- a/typetalk/v1/topics_test.go
+++ b/typetalk/v1/topics_test.go
@@ -18,7 +18,7 @@ func Test_TopicsService_CreateTopic_should_create_a_topic(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "create-topic.json")
 	mux.HandleFunc("/topics",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"name":             "nulab",
 				"spaceKey":         "balun",
@@ -146,7 +146,7 @@ func Test_TopicsService_UpdateTopicMembers_should_add_some_topic_members(t *test
 	b, _ := ioutil.ReadFile(fixturesPath + "update-topic-members.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/members/update", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"addAccountIds[0]":                        1,
 				"addGroupIds[0]":                          1,
@@ -187,7 +187,7 @@ func Test_TopicsService_FavoriteTopic_should_favorite_topic(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "favorite-topic.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/favorite", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v1/topics_test.go
+++ b/typetalk/v1/topics_test.go
@@ -97,7 +97,7 @@ func Test_TopicsService_GetTopicDetails_should_get_a_topic_details(t *testing.T)
 	b, _ := ioutil.ReadFile(fixturesPath + "get-topic-details.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -119,7 +119,7 @@ func Test_TopicsService_GetTopicMessages_should_get_some_topic_messages(t *testi
 	b, _ := ioutil.ReadFile(fixturesPath + "get-topic-messages.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"count":     10,
 				"from":      3,
@@ -259,7 +259,7 @@ func Test_TopicsService_GetMyTopics_should_get_some_topics(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-topics.json")
 	mux.HandleFunc("/topics",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v1/topics_test.go
+++ b/typetalk/v1/topics_test.go
@@ -75,7 +75,7 @@ func Test_TopicsService_DeleteTopic_should_delete_a_topic(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "delete-topic.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "DELETE")
+			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
@@ -209,7 +209,7 @@ func Test_TopicsService_UnfavoriteTopic_should_unfavorite_topic(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "unfavorite-topic.json")
 	mux.HandleFunc(fmt.Sprintf("/topics/%d/favorite", topicId),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "DELETE")
+			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v2/likes_test.go
+++ b/typetalk/v2/likes_test.go
@@ -99,7 +99,7 @@ func Test_LikesService_ReadReceivedLikes_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "read-received-likes.json")
 	mux.HandleFunc("/likes/receive/bookmark/save",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"spaceKey": "qwerty",
 				"likeId":   1,

--- a/typetalk/v2/likes_test.go
+++ b/typetalk/v2/likes_test.go
@@ -18,7 +18,7 @@ func Test_LikesService_GetLikesReceive_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-likes-receive.json")
 	mux.HandleFunc("/likes/receive",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"spaceKey": "qwerty",
 				"from":     1,
@@ -45,7 +45,7 @@ func Test_LikesService_GetLikesGive_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-likes-give.json")
 	mux.HandleFunc("/likes/give",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"spaceKey": "qwerty",
 				"from":     1,
@@ -72,7 +72,7 @@ func Test_LikesService_GetLikesDiscover_should_get_Likes(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-likes-discover.json")
 	mux.HandleFunc("/likes/discover",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"spaceKey": "qwerty",
 				"from":     1,

--- a/typetalk/v2/mentions_test.go
+++ b/typetalk/v2/mentions_test.go
@@ -17,7 +17,7 @@ func Test_MentionsService_GetMentionList_should_get_some_mentions(t *testing.T) 
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "get-mention-list.json")
 	mux.HandleFunc("/mentions", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestQueryValues(t, r, Values{
 			"spaceKey": "qwerty",
 			"from":     10,

--- a/typetalk/v2/messages_test.go
+++ b/typetalk/v2/messages_test.go
@@ -22,7 +22,7 @@ func Test_MessagesService_GetDirectMessages_should_get_some_direct_messages(t *t
 	b, _ := ioutil.ReadFile(fixturesPath + "get-direct-messages.json")
 	mux.HandleFunc(fmt.Sprintf("/spaces/%s/messages/@%s", spaceKey, accountName),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"count":     10,
 				"from":      1,
@@ -97,7 +97,7 @@ func Test_MessagesService_SearchMessages_should_get_some_posts(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "search-messages.json")
 	mux.HandleFunc("/search/posts",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"spaceKey":       "qwerty",
 				"q":              "hello",

--- a/typetalk/v2/messages_test.go
+++ b/typetalk/v2/messages_test.go
@@ -50,7 +50,7 @@ func Test_MessagesService_PostDirectMessage_should_post_dairect_message(t *testi
 	b, _ := ioutil.ReadFile(fixturesPath + "post-direct-message.json")
 	mux.HandleFunc(fmt.Sprintf("/spaces/%s/messages/@%s", spaceKey, accountName),
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "POST")
+			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
 				"message":                 "hello",
 				"replyTo":                 2,

--- a/typetalk/v2/notifications_test.go
+++ b/typetalk/v2/notifications_test.go
@@ -39,7 +39,7 @@ func Test_NotificationsService_ReadNotification_should_read_notification(t *test
 	b, _ := ioutil.ReadFile(fixturesPath + "read-notification.json")
 	mux.HandleFunc("/notifications",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "PUT")
+			TestMethod(t, r, http.MethodPut)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v2/notifications_test.go
+++ b/typetalk/v2/notifications_test.go
@@ -18,7 +18,7 @@ func Test_NotificationsService_GetNotificationCount_should_get_notification_coun
 	b, _ := ioutil.ReadFile(fixturesPath + "get-notification-count.json")
 	mux.HandleFunc("/notifications/status",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 

--- a/typetalk/v2/topics_test.go
+++ b/typetalk/v2/topics_test.go
@@ -18,7 +18,7 @@ func Test_TopicsService_GetMyTopics_should_get_some_topics(t *testing.T) {
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-topics.json")
 	mux.HandleFunc("/topics",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"spaceKey": "qwerty",
 			})
@@ -44,7 +44,7 @@ func Test_MessagesService_GetMyDirectMessageTopics_should_get_some_direct_messag
 	b, _ := ioutil.ReadFile(fixturesPath + "get-dm-topics.json")
 	mux.HandleFunc("/messages",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
 				"spaceKey": "qwerty",
 			})

--- a/typetalk/v3/accounts_test.go
+++ b/typetalk/v3/accounts_test.go
@@ -17,7 +17,7 @@ func Test_AccountsService_GetMyFriends_should_get_some_friends(t *testing.T) {
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-friends.json")
 	mux.HandleFunc("/search/friends", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestQueryValues(t, r, Values{
 			"spaceKey": "qwerty",
 			"q":        "hello",

--- a/typetalk/v3/notifications_test.go
+++ b/typetalk/v3/notifications_test.go
@@ -18,7 +18,7 @@ func Test_NotificationsService_ReadNotification_should_read_notification(t *test
 	b, _ := ioutil.ReadFile(fixturesPath + "read-notification.json")
 	mux.HandleFunc("/notifications",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "PUT")
+			TestMethod(t, r, http.MethodPut)
 			TestFormValues(t, r, Values{
 				"spaceKey": "qwerty",
 			})

--- a/typetalk/v4/accounts_test.go
+++ b/typetalk/v4/accounts_test.go
@@ -17,7 +17,7 @@ func Test_AccountsService_GetMyFriends_should_get_some_friends(t *testing.T) {
 	defer teardown()
 	b, _ := ioutil.ReadFile(fixturesPath + "get-my-friends.json")
 	mux.HandleFunc("/search/friends", func(w http.ResponseWriter, r *http.Request) {
-		TestMethod(t, r, "GET")
+		TestMethod(t, r, http.MethodGet)
 		TestQueryValues(t, r, Values{
 			"spaceKey": "qwerty",
 			"q":        "hello",

--- a/typetalk/v5/notifications_test.go
+++ b/typetalk/v5/notifications_test.go
@@ -18,7 +18,7 @@ func Test_NotificationsService_GetNotificationCount_should_get_notification_coun
 	b, _ := ioutil.ReadFile(fixturesPath + "get-notification-count.json")
 	mux.HandleFunc("/notifications/status",
 		func(w http.ResponseWriter, r *http.Request) {
-			TestMethod(t, r, "GET")
+			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 


### PR DESCRIPTION
Can we use const value http.Method* from standard package instead of using string (i.e. "GET") ?