### PR TITLE
Fix "should be..." warnings

### DIFF
--- a/example/access_token/main.go
+++ b/example/access_token/main.go
@@ -1,4 +1,4 @@
-package typetalk_token
+package main
 
 import (
 	"context"
@@ -10,7 +10,7 @@ func main() {
 	client := v1.NewClient(nil)
 	client.SetTypetalkToken("yourTypetalkToken")
 	ctx := context.Background()
-	topicId := 1
+	topicID := 1
 	message := "Hello"
-	client.Messages.PostMessage(ctx, topicId, message, nil)
+	client.Messages.PostMessage(ctx, topicID, message, nil)
 }

--- a/example/typetalk_token/main.go
+++ b/example/typetalk_token/main.go
@@ -1,4 +1,4 @@
-package typetalk_token
+package main
 
 import (
 	"context"

--- a/tests/integration/messages_test.go
+++ b/tests/integration/messages_test.go
@@ -10,27 +10,27 @@ import (
 )
 
 func Test_V1_Messages_GetMessage_should_get_a_message(t *testing.T) {
-	result, resp, err := clientV1.Messages.GetMessage(context.Background(), topicId, postId)
+	result, resp, err := clientV1.Messages.GetMessage(context.Background(), topicID, postID)
 	test(t, result, resp, err)
 }
 
 func Test_V1_Messages_PostMessage_should_post_a_message(t *testing.T) {
-	result, resp, err := clientV1.Messages.PostMessage(context.Background(), topicId, "go-typetalk - Test_Messages_PostMessage_should_post_a_message", nil)
+	result, resp, err := clientV1.Messages.PostMessage(context.Background(), topicID, "go-typetalk - Test_Messages_PostMessage_should_post_a_message", nil)
 	test(t, result, resp, err)
 }
 
 func Test_V1_Messages_UpdateMessage_should_update_a_message(t *testing.T) {
-	result, resp, err := clientV1.Messages.UpdateMessage(context.Background(), topicId, postId, "go-typetalk - Test_Messages_UpdateMessage_should_update_a_message")
+	result, resp, err := clientV1.Messages.UpdateMessage(context.Background(), topicID, postID, "go-typetalk - Test_Messages_UpdateMessage_should_update_a_message")
 	test(t, result, resp, err)
 }
 
 func Test_V1_Messages_GetMessage_should_get_a_message_using_Typetalk_Token(t *testing.T) {
-	result, resp, err := clientUsingTypetalkTokenV1.Messages.GetMessage(context.Background(), topicId, postId)
+	result, resp, err := clientUsingTypetalkTokenV1.Messages.GetMessage(context.Background(), topicID, postID)
 	test(t, result, resp, err)
 }
 
 func Test_V1_Messages_PostMessage_should_post_a_message_using_Typetalk_Token(t *testing.T) {
-	result, resp, err := clientUsingTypetalkTokenV1.Messages.PostMessage(context.Background(), topicId, "go-typetalk - Test_Messages_PostMessage_should_post_a_message_using_Typetalk_Token", nil)
+	result, resp, err := clientUsingTypetalkTokenV1.Messages.PostMessage(context.Background(), topicID, "go-typetalk - Test_Messages_PostMessage_should_post_a_message_using_Typetalk_Token", nil)
 	test(t, result, resp, err)
 }
 
@@ -38,7 +38,7 @@ func Test_V2_Messages_SearchMessages_should_some_messages(t *testing.T) {
 	from := time.Date(2018, time.May, 1, 0, 0, 0, 0, time.Local)
 	to := time.Now()
 	opt := &SearchMessagesOptions{
-		TopicIDs:       []int{topicId},
+		TopicIDs:       []int{topicID},
 		HasAttachments: false,
 		From:           &from,
 		To:             &to,

--- a/tests/integration/typetalk_test.go
+++ b/tests/integration/typetalk_test.go
@@ -23,8 +23,8 @@ var (
 	clientUsingTypetalkTokenV1 *v1.Client
 	clientUsingTypetalkTokenV2 *v2.Client
 	clientUsingTypetalkTokenV3 *v3.Client
-	topicId                    int
-	postId                     int
+	topicID                    int
+	postID                     int
 	spaceKey                   string
 )
 
@@ -37,20 +37,20 @@ type AccessToken struct {
 
 func init() {
 	spaceKey = os.Getenv("TT_SPACE_KEY")
-	clientId := os.Getenv("TT_CLIENT_ID")
+	clientID := os.Getenv("TT_CLIENT_ID")
 	clientSecret := os.Getenv("TT_CLIENT_SECRET")
 	if v, err := strconv.Atoi(os.Getenv("TT_TOPIC_ID")); err == nil {
-		topicId = v
+		topicID = v
 	}
 	if v, err := strconv.Atoi(os.Getenv("TT_POST_ID")); err == nil {
-		postId = v
+		postID = v
 	}
-	if clientId == "" || clientSecret == "" {
+	if clientID == "" || clientSecret == "" {
 		print("!!! Integration test using OAuth2 requires client_id and client_secret. !!!\n\n")
 		clientV1 = v1.NewClient(nil)
 	} else {
 		form := url.Values{}
-		form.Add("client_id", clientId)
+		form.Add("client_id", clientID)
 		form.Add("client_secret", clientSecret)
 		form.Add("grant_type", "client_credentials")
 		form.Add("scope", "topic.read,topic.post,topic.write,topic.delete,my")

--- a/typetalk/v1/accounts.go
+++ b/typetalk/v1/accounts.go
@@ -19,7 +19,7 @@ type Account struct {
 	ImageURL       string     `json:"imageUrl"`
 	IsBot          bool       `json:"isBot"`
 	Lang           string     `json:"lang"`
-	TimezoneId     string     `json:"timezoneId"`
+	TimezoneID     string     `json:"timezoneId"`
 	CreatedAt      *time.Time `json:"createdAt"`
 	UpdatedAt      *time.Time `json:"updatedAt"`
 	ImageUpdatedAt *time.Time `json:"imageUpdatedAt"`
@@ -57,6 +57,8 @@ type OnlineStatus struct {
 	Accounts []*AccountStatus `json:"accounts"`
 }
 
+// GetMyProfile fetches the user's account information.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-profile
 func (s *AccountsService) GetMyProfile(ctx context.Context) (*MyProfile, *shared.Response, error) {
 	u := "profile"
@@ -68,6 +70,8 @@ func (s *AccountsService) GetMyProfile(ctx context.Context) (*MyProfile, *shared
 	return result, resp, nil
 }
 
+// GetFriendProfile fetches other user's account information.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-friend-profile
 func (s *AccountsService) GetFriendProfile(ctx context.Context, accountName string) (*Profile, *shared.Response, error) {
 	u := fmt.Sprintf("profile/%s", accountName)
@@ -85,6 +89,8 @@ type GetMyFriendsOptions struct {
 	Count  int    `json:"count,omitempty"`
 }
 
+// GetMyFriends searches other user who belong to a topic in common.
+//
 // Deprecated: Use GetMyFrieands in github.com/nulab/go-typetalk/typetalk/v4
 func (s *AccountsService) GetMyFriends(ctx context.Context, opt *GetMyFriendsOptions) (*Friends, *shared.Response, error) {
 	u, err := internal.AddQueries("search/friends", opt)
@@ -103,6 +109,8 @@ type searchAccountsOptions struct {
 	NameOrEmailAddress string `json:"nameOrEmailAddress,omitempty"`
 }
 
+// SearchAccounts searches acocunts by name or mail address.
+//
 // Deprecated: Use GetMyFrieands in github.com/nulab/go-typetalk/typetalk/v4
 func (s *AccountsService) SearchAccounts(ctx context.Context, nameOrEmailAddress string) (*Account, *shared.Response, error) {
 	u, err := internal.AddQueries("search/accounts", &searchAccountsOptions{nameOrEmailAddress})
@@ -121,6 +129,8 @@ type getOnlineStatusOptions struct {
 	AccountIds []int `json:"accountIds[%d],omitempty"`
 }
 
+// GetOnlineStatus fetches an user's online status.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-online-status
 func (s *AccountsService) GetOnlineStatus(ctx context.Context, accountIds ...int) (*OnlineStatus, *shared.Response, error) {
 	u, err := internal.AddQueries("accounts/status", &getOnlineStatusOptions{accountIds})

--- a/typetalk/v1/files.go
+++ b/typetalk/v1/files.go
@@ -21,9 +21,11 @@ type AttachmentFile struct {
 	FileSize    int    `json:"fileSize"`
 }
 
+// UploadAttachmentFile uploads attachment file.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/upload-attachment
-func (s *FilesService) UploadAttachmentFile(ctx context.Context, topicId int, file *os.File) (*AttachmentFile, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%v/attachments", topicId)
+func (s *FilesService) UploadAttachmentFile(ctx context.Context, topicID int, file *os.File) (*AttachmentFile, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%v/attachments", topicID)
 	stat, err := file.Stat()
 	if err != nil {
 		return nil, nil, err
@@ -47,9 +49,11 @@ func (s *FilesService) UploadAttachmentFile(ctx context.Context, topicId int, fi
 	return attachmentFile, resp, nil
 }
 
+// DownloadAttachmentFile downloads attachemnt file.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/download-attachment
-func (s *FilesService) DownloadAttachmentFile(ctx context.Context, topicId, postId, attachmentId int, filename string) (io.ReadCloser, error) {
-	u := fmt.Sprintf("topics/%d/posts/%d/attachments/%d/%s", topicId, postId, attachmentId, filename)
+func (s *FilesService) DownloadAttachmentFile(ctx context.Context, topicID, postID, attachmentID int, filename string) (io.ReadCloser, error) {
+	u := fmt.Sprintf("topics/%d/posts/%d/attachments/%d/%s", topicID, postID, attachmentID, filename)
 
 	req, err := s.client.NewRequest(http.MethodGet, u, nil)
 	if err != nil {

--- a/typetalk/v1/files_test.go
+++ b/typetalk/v1/files_test.go
@@ -17,16 +17,16 @@ import (
 func Test_FilesService_UploadAttachmentFile_should_upload_an_attachment_file(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "upload-attachment-file.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%v/attachments", topicId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%v/attachments", topicID), func(w http.ResponseWriter, r *http.Request) {
 		TestMethod(t, r, http.MethodPost)
 		fmt.Fprint(w, string(b))
 	})
 
 	f, _ := os.Open(fixturesPath + "sample.jpg")
 	defer f.Close()
-	result, _, err := client.Files.UploadAttachmentFile(context.Background(), topicId, f)
+	result, _, err := client.Files.UploadAttachmentFile(context.Background(), topicID, f)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -40,12 +40,12 @@ func Test_FilesService_UploadAttachmentFile_should_upload_an_attachment_file(t *
 func Test_FilesService_DownloadAttachmentFile_should_download_an_attachment_file(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	postId := 1
-	attachmentId := 1
+	topicID := 1
+	postID := 1
+	attachmentID := 1
 	filename := "sample.jpg"
 	b, _ := ioutil.ReadFile(fixturesPath + filename)
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/attachments/%d/%s", topicId, postId, attachmentId, filename), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/attachments/%d/%s", topicID, postID, attachmentID, filename), func(w http.ResponseWriter, r *http.Request) {
 		TestMethod(t, r, http.MethodGet)
 		TestHeader(t, r, "Accept", DefaultMediaType)
 		w.Header().Set("Content-Type", "application/octet-stream")
@@ -53,7 +53,7 @@ func Test_FilesService_DownloadAttachmentFile_should_download_an_attachment_file
 		fmt.Fprint(w, string(b))
 	})
 
-	reader, err := client.Files.DownloadAttachmentFile(context.Background(), topicId, postId, attachmentId, filename)
+	reader, err := client.Files.DownloadAttachmentFile(context.Background(), topicID, postID, attachmentID, filename)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}

--- a/typetalk/v1/likes.go
+++ b/typetalk/v1/likes.go
@@ -39,6 +39,8 @@ type GetLikesOptions struct {
 	From int `json:"from,omitempty"`
 }
 
+// GetLikesReceive fetches received likes list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-receive/
 func (s *LikesService) GetLikesReceive(ctx context.Context, opt *GetLikesOptions) ([]*ReceiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/receive", opt)
@@ -55,6 +57,8 @@ func (s *LikesService) GetLikesReceive(ctx context.Context, opt *GetLikesOptions
 	return result.LikedPosts, resp, nil
 }
 
+// GetLikesGive fetches given likes list. Those likes are given by your account.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-give/
 func (s *LikesService) GetLikesGive(ctx context.Context, opt *GetLikesOptions) ([]*GiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/give", opt)
@@ -71,6 +75,8 @@ func (s *LikesService) GetLikesGive(ctx context.Context, opt *GetLikesOptions) (
 	return result.GiveLikedPost, resp, nil
 }
 
+// GetLikesDiscover fetches given likes list. Those likes are given by all the accounts.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-discover/
 func (s *LikesService) GetLikesDiscover(ctx context.Context, opt *GetLikesOptions) ([]*DiscoverLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/discover", opt)
@@ -88,7 +94,7 @@ func (s *LikesService) GetLikesDiscover(ctx context.Context, opt *GetLikesOption
 }
 
 type readReceivedLikesOptions struct {
-	LikeId int `json:"likeId,omitempty"`
+	LikeID int `json:"likeId,omitempty"`
 }
 
 type ReadReceivedLikesResult struct {
@@ -100,12 +106,14 @@ type ReadReceivedLikesResult struct {
 	} `json:"like"`
 }
 
+// ReadReceivedLikes marks likes as read.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/save-read-likes/
-func (s *LikesService) ReadReceivedLikes(ctx context.Context, likeId int) (*ReadReceivedLikesResult, *shared.Response, error) {
+func (s *LikesService) ReadReceivedLikes(ctx context.Context, likeID int) (*ReadReceivedLikesResult, *shared.Response, error) {
 	u := "likes/receive/bookmark/save"
 
 	var result *ReadReceivedLikesResult
-	resp, err := s.client.Post(ctx, u, &readReceivedLikesOptions{likeId}, result)
+	resp, err := s.client.Post(ctx, u, &readReceivedLikesOptions{likeID}, result)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/typetalk/v1/mentions.go
+++ b/typetalk/v1/mentions.go
@@ -17,9 +17,11 @@ type Mention struct {
 	Post   *Post      `json:"post"`
 }
 
+// ReadMention marks a mention as read.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/save-read-mention
-func (s *MentionsService) ReadMention(ctx context.Context, mentionId int) (*Mention, *shared.Response, error) {
-	u := fmt.Sprintf("mentions/%d", mentionId)
+func (s *MentionsService) ReadMention(ctx context.Context, mentionID int) (*Mention, *shared.Response, error) {
+	u := fmt.Sprintf("mentions/%d", mentionID)
 	var result *struct {
 		Mention Mention `json:"mention"`
 	}
@@ -35,6 +37,8 @@ type GetMentionListOptions struct {
 	Unread bool `json:"unread,omitempty"`
 }
 
+// GetMentionList fetches mentions list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-mentions
 func (s *MentionsService) GetMentionList(ctx context.Context, opt *GetMentionListOptions) ([]*Mention, *shared.Response, error) {
 	u, err := internal.AddQueries("mentions", opt)

--- a/typetalk/v1/mentions_test.go
+++ b/typetalk/v1/mentions_test.go
@@ -15,14 +15,14 @@ import (
 func Test_MentionsService_ReadMention_should_read_a_mention(t *testing.T) {
 	setup()
 	defer teardown()
-	mentionId := 1
+	mentionID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "read-mention.json")
-	mux.HandleFunc(fmt.Sprintf("/mentions/%d", mentionId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/mentions/%d", mentionID), func(w http.ResponseWriter, r *http.Request) {
 		TestMethod(t, r, http.MethodPut)
 		fmt.Fprint(w, string(b))
 	})
 
-	result, _, err := client.Mentions.ReadMention(context.Background(), mentionId)
+	result, _, err := client.Mentions.ReadMention(context.Background(), mentionID)
 	if err != nil {
 		t.Errorf("returned error: %v", err)
 	}

--- a/typetalk/v1/messages.go
+++ b/typetalk/v1/messages.go
@@ -98,9 +98,11 @@ type postMessageOptions struct {
 	Message string `json:"message,omitempty"`
 }
 
+// PostMessage posts a message.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/post-message
-func (s *MessagesService) PostMessage(ctx context.Context, topicId int, message string, opt *PostMessageOptions) (*PostedMessageResult, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%v", topicId)
+func (s *MessagesService) PostMessage(ctx context.Context, topicID int, message string, opt *PostMessageOptions) (*PostedMessageResult, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%v", topicID)
 	if opt == nil {
 		opt = &PostMessageOptions{}
 	}
@@ -116,9 +118,11 @@ type updateMessageOptions struct {
 	Message string `json:"message"`
 }
 
+// UpdateMessage updates a message.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-message
-func (s *MessagesService) UpdateMessage(ctx context.Context, topicId, postId int, message string) (*UpdatedMessageResult, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/posts/%d", topicId, postId)
+func (s *MessagesService) UpdateMessage(ctx context.Context, topicID, postID int, message string) (*UpdatedMessageResult, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/posts/%d", topicID, postID)
 	var result *UpdatedMessageResult
 	resp, err := s.client.Put(ctx, u, &updateMessageOptions{Message: message}, &result)
 	if err != nil {
@@ -127,9 +131,11 @@ func (s *MessagesService) UpdateMessage(ctx context.Context, topicId, postId int
 	return result, resp, nil
 }
 
+// DeleteMessage deletes a message.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-message
-func (s *MessagesService) DeleteMessage(ctx context.Context, topicId, postId int) (*Post, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/posts/%d", topicId, postId)
+func (s *MessagesService) DeleteMessage(ctx context.Context, topicID, postID int) (*Post, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/posts/%d", topicID, postID)
 	var result *Post
 	resp, err := s.client.Delete(ctx, u, &result)
 	if err != nil {
@@ -138,9 +144,11 @@ func (s *MessagesService) DeleteMessage(ctx context.Context, topicId, postId int
 	return result, resp, nil
 }
 
+// GetMessage gets a message.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-message
-func (s *MessagesService) GetMessage(ctx context.Context, topicId, postId int) (*Message, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/posts/%d", topicId, postId)
+func (s *MessagesService) GetMessage(ctx context.Context, topicID, postID int) (*Message, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/posts/%d", topicID, postID)
 	var result *Message
 	resp, err := s.client.Get(ctx, u, &result)
 	if err != nil {
@@ -149,9 +157,11 @@ func (s *MessagesService) GetMessage(ctx context.Context, topicId, postId int) (
 	return result, resp, nil
 }
 
+// LikeMessage marks a message as liked.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/favorite-topic
-func (s *MessagesService) LikeMessage(ctx context.Context, topicId, postId int) (*LikedMessageResult, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/posts/%d/like", topicId, postId)
+func (s *MessagesService) LikeMessage(ctx context.Context, topicID, postID int) (*LikedMessageResult, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/posts/%d/like", topicID, postID)
 	var result *LikedMessageResult
 	resp, err := s.client.Post(ctx, u, nil, &result)
 	if err != nil {
@@ -160,9 +170,11 @@ func (s *MessagesService) LikeMessage(ctx context.Context, topicId, postId int) 
 	return result, resp, nil
 }
 
+// UnlikeMessage marks a message as unliked.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/unfavorite-topic
-func (s *MessagesService) UnlikeMessage(ctx context.Context, topicId, postId int) (*Like, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/posts/%d/like", topicId, postId)
+func (s *MessagesService) UnlikeMessage(ctx context.Context, topicID, postID int) (*Like, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/posts/%d/like", topicID, postID)
 	var result *struct {
 		Like Like `json:"like"`
 	}
@@ -173,6 +185,8 @@ func (s *MessagesService) UnlikeMessage(ctx context.Context, topicId, postId int
 	return &result.Like, resp, nil
 }
 
+// PostDirectMessage posts direct message.
+//
 // Deprecated: Use PostDirectMessage in github.com/nulab/go-typetalk/typetalk/v2
 func (s *MessagesService) PostDirectMessage(ctx context.Context, accountName, message string, opt *PostMessageOptions) (*PostedMessageResult, *shared.Response, error) {
 	u := fmt.Sprintf("messages/@%s", accountName)
@@ -193,6 +207,8 @@ type GetMessagesOptions struct {
 	Direction string `json:"direction,omitempty"`
 }
 
+// GetDirectMessages fetches direct messages list.
+//
 // Deprecated: Use GetDirectMessages in github.com/nulab/go-typetalk/typetalk/v2
 func (s *MessagesService) GetDirectMessages(ctx context.Context, accountName string, opt *GetMessagesOptions) (*DirectMessages, *shared.Response, error) {
 	u, err := internal.AddQueries(fmt.Sprintf("messages/@%s", accountName), opt)
@@ -207,6 +223,8 @@ func (s *MessagesService) GetDirectMessages(ctx context.Context, accountName str
 	return result, resp, nil
 }
 
+// GetMyDirectMessageTopics fetches direct message topics list.
+//
 // Deprecated: Use GetMyDirectMessageTopics in github.com/nulab/go-typetalk/typetalk/v2
 func (s *MessagesService) GetMyDirectMessageTopics(ctx context.Context) ([]*DirectMessageTopic, *shared.Response, error) {
 	u := "messages"

--- a/typetalk/v1/messages_test.go
+++ b/typetalk/v1/messages_test.go
@@ -15,9 +15,9 @@ import (
 func Test_MessagesService_PostMessage_should_post_a_message(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "post-message.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%v", topicId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/topics/%v", topicID), func(w http.ResponseWriter, r *http.Request) {
 		TestMethod(t, r, http.MethodPost)
 		TestFormValues(t, r, Values{
 			"message":                 "hello",
@@ -39,7 +39,7 @@ func Test_MessagesService_PostMessage_should_post_a_message(t *testing.T) {
 		fmt.Fprint(w, string(b))
 	})
 
-	result, _, err := client.Messages.PostMessage(context.Background(), topicId, "hello", &PostMessageOptions{
+	result, _, err := client.Messages.PostMessage(context.Background(), topicID, "hello", &PostMessageOptions{
 		ReplyTo:      2,
 		ShowLinkMeta: true,
 		FileKeys:     []string{"key0", "key1", "key2"},
@@ -60,18 +60,18 @@ func Test_MessagesService_PostMessage_should_post_a_message(t *testing.T) {
 func Test_MessagesService_UpdateMessage_should_update_a_message(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	postId := 1
+	topicID := 1
+	postID := 1
 	message := "hello"
 	b, _ := ioutil.ReadFile(fixturesPath + "update-message.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicId, postId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicID, postID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPut)
 			TestFormValues(t, r, Values{"message": message})
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Messages.UpdateMessage(context.Background(), topicId, postId, message)
+	result, _, err := client.Messages.UpdateMessage(context.Background(), topicID, postID, message)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -85,16 +85,16 @@ func Test_MessagesService_UpdateMessage_should_update_a_message(t *testing.T) {
 func Test_MessagesService_DeleteMessage_should_delete_a_message(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	postId := 1
+	topicID := 1
+	postID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "delete-message.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicId, postId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicID, postID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Messages.DeleteMessage(context.Background(), topicId, postId)
+	result, _, err := client.Messages.DeleteMessage(context.Background(), topicID, postID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -108,16 +108,16 @@ func Test_MessagesService_DeleteMessage_should_delete_a_message(t *testing.T) {
 func Test_MessagesService_GetMessage_should_get_a_message(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	postId := 1
+	topicID := 1
+	postID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "get-message.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicId, postId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d", topicID, postID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Messages.GetMessage(context.Background(), topicId, postId)
+	result, _, err := client.Messages.GetMessage(context.Background(), topicID, postID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -131,16 +131,16 @@ func Test_MessagesService_GetMessage_should_get_a_message(t *testing.T) {
 func Test_MessagesService_LikeMessage_should_like_a_message(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	postId := 1
+	topicID := 1
+	postID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "like-message.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/like", topicId, postId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/like", topicID, postID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPost)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Messages.LikeMessage(context.Background(), topicId, postId)
+	result, _, err := client.Messages.LikeMessage(context.Background(), topicID, postID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -154,16 +154,16 @@ func Test_MessagesService_LikeMessage_should_like_a_message(t *testing.T) {
 func Test_MessagesService_UnikeMessage_should_unlike_a_message(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	postId := 1
+	topicID := 1
+	postID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "unlike-message.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/like", topicId, postId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/posts/%d/like", topicID, postID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Messages.UnlikeMessage(context.Background(), topicId, postId)
+	result, _, err := client.Messages.UnlikeMessage(context.Background(), topicID, postID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}

--- a/typetalk/v1/notifications.go
+++ b/typetalk/v1/notifications.go
@@ -43,6 +43,8 @@ type NotificationCount struct {
 	} `json:"directMessage"`
 }
 
+// GetNotificationList fetches notifications list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-notifications
 func (s *NotificationsService) GetNotificationList(ctx context.Context) (*NotificationList, *shared.Response, error) {
 	u := "notifications"
@@ -54,6 +56,8 @@ func (s *NotificationsService) GetNotificationList(ctx context.Context) (*Notifi
 	return result, resp, nil
 }
 
+// GetNotificationCount fetches notification counts.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-notification-status
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *shared.Response, error) {
 	u := "notifications/status"
@@ -65,6 +69,8 @@ func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*Notif
 	return result, resp, nil
 }
 
+// ReadNotification marks notifications as read.
+//
 // Deprecated: Use ReadNotification in github.com/nulab/go-typetalk/typetalk/v3
 func (s *NotificationsService) ReadNotification(ctx context.Context) (*Access, *shared.Response, error) {
 	u := "notifications"

--- a/typetalk/v1/organizations.go
+++ b/typetalk/v1/organizations.go
@@ -64,6 +64,8 @@ type organizationsGetOptions struct {
 	ExcludesGuest bool `json:"excludesGuest,omitempty"`
 }
 
+// GetMyOrganizations fetches organizations list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-spaces
 func (s *OrganizationsService) GetMyOrganizations(ctx context.Context, excludesGuest bool) ([]*Organization, *shared.Response, error) {
 	u, err := internal.AddQueries("spaces", &organizationsGetOptions{excludesGuest})
@@ -80,6 +82,8 @@ func (s *OrganizationsService) GetMyOrganizations(ctx context.Context, excludesG
 	return result.MySpaces, resp, nil
 }
 
+// GetOrganizationMembers fetches an organization's members list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-space-members
 func (s *OrganizationsService) GetOrganizationMembers(ctx context.Context, spaceKey string) (*OrganizationMembers, *shared.Response, error) {
 	u := fmt.Sprintf("spaces/%s/members", spaceKey)

--- a/typetalk/v1/talks.go
+++ b/typetalk/v1/talks.go
@@ -50,9 +50,11 @@ type CreateTalkOptions struct {
 	PostIds  []int  `json:"postIds[%d],omitempty"`
 }
 
+// CreateTalk creates a talk.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/create-talk
-func (s *TalksService) CreateTalk(ctx context.Context, topicId int, talkName string, postIds ...int) (*CreatedTalkResult, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/talks", topicId)
+func (s *TalksService) CreateTalk(ctx context.Context, topicID int, talkName string, postIds ...int) (*CreatedTalkResult, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/talks", topicID)
 	var result *CreatedTalkResult
 	resp, err := s.client.Post(ctx, u, &CreateTalkOptions{talkName, postIds}, &result)
 	if err != nil {
@@ -65,9 +67,11 @@ type updateTalkOptions struct {
 	TalkName string `json:"talkName,omitempty"`
 }
 
+// UpdateTalk updates a talk.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-talk
-func (s *TalksService) UpdateTalk(ctx context.Context, topicId, talkId int, talkName string) (*UpdatedTalkResult, *shared.Response, error) {
-	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d", topicId, talkId), &updateTalkOptions{talkName})
+func (s *TalksService) UpdateTalk(ctx context.Context, topicID, talkID int, talkName string) (*UpdatedTalkResult, *shared.Response, error) {
+	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d", topicID, talkID), &updateTalkOptions{talkName})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -80,9 +84,11 @@ func (s *TalksService) UpdateTalk(ctx context.Context, topicId, talkId int, talk
 	return result, resp, nil
 }
 
+// DeleteTalk deletes a talk.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-talk
-func (s *TalksService) DeleteTalk(ctx context.Context, topicId, talkId int) (*DeletedTalkResult, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/talks/%d", topicId, talkId)
+func (s *TalksService) DeleteTalk(ctx context.Context, topicID, talkID int) (*DeletedTalkResult, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/talks/%d", topicID, talkID)
 	var result *DeletedTalkResult
 	resp, err := s.client.Delete(ctx, u, &result)
 	if err != nil {
@@ -91,9 +97,11 @@ func (s *TalksService) DeleteTalk(ctx context.Context, topicId, talkId int) (*De
 	return result, resp, nil
 }
 
+// GetTalkList fetches talks list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-talks
-func (s *TalksService) GetTalkList(ctx context.Context, topicId int) ([]*Talk, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/talks", topicId)
+func (s *TalksService) GetTalkList(ctx context.Context, topicID int) ([]*Talk, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/talks", topicID)
 	var result *struct {
 		Talks []*Talk `json:"talks"`
 	}
@@ -104,9 +112,11 @@ func (s *TalksService) GetTalkList(ctx context.Context, topicId int) ([]*Talk, *
 	return result.Talks, resp, nil
 }
 
+// GetMessagesInTalk fetches messages list in a talk.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-talk
-func (s *TalksService) GetMessagesInTalk(ctx context.Context, topicId, talkId int, opt *GetMessagesOptions) (*MessagesInTalk, *shared.Response, error) {
-	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d/posts", topicId, talkId), opt)
+func (s *TalksService) GetMessagesInTalk(ctx context.Context, topicID, talkID int, opt *GetMessagesOptions) (*MessagesInTalk, *shared.Response, error) {
+	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d/posts", topicID, talkID), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -122,9 +132,11 @@ type addMessageToTalkOptions struct {
 	PostIds []int `json:"postIds[%d],omitempty"`
 }
 
+// AddMessagesToTalk adds messages to a talk.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/add-message-to-talk
-func (s *TalksService) AddMessagesToTalk(ctx context.Context, topicId, talkId int, postIds ...int) (*MessagesInTalk, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/talks/%d/posts", topicId, talkId)
+func (s *TalksService) AddMessagesToTalk(ctx context.Context, topicID, talkID int, postIds ...int) (*MessagesInTalk, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/talks/%d/posts", topicID, talkID)
 	var result *MessagesInTalk
 	resp, err := s.client.Post(ctx, u, &addMessageToTalkOptions{postIds}, &result)
 	if err != nil {
@@ -135,9 +147,11 @@ func (s *TalksService) AddMessagesToTalk(ctx context.Context, topicId, talkId in
 
 type removeMessagesFromTalkOptions addMessageToTalkOptions
 
+// RemoveMessagesFromTalk removes messages from a talk.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/remove-message-from-talk
-func (s *TalksService) RemoveMessagesFromTalk(ctx context.Context, topicId, talkId int, postIds ...int) (*RemovedMessagesResult, *shared.Response, error) {
-	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d/posts", topicId, talkId), &removeMessagesFromTalkOptions{postIds})
+func (s *TalksService) RemoveMessagesFromTalk(ctx context.Context, topicID, talkID int, postIds ...int) (*RemovedMessagesResult, *shared.Response, error) {
+	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d/posts", topicID, talkID), &removeMessagesFromTalkOptions{postIds})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/typetalk/v1/talks_test.go
+++ b/typetalk/v1/talks_test.go
@@ -15,10 +15,10 @@ import (
 func Test_TalksService_CreateTalk_should_create_a_talk(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	talkName := "test"
 	b, _ := ioutil.ReadFile(fixturesPath + "create-talk.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
@@ -30,7 +30,7 @@ func Test_TalksService_CreateTalk_should_create_a_talk(t *testing.T) {
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Talks.CreateTalk(context.Background(), topicId, talkName, 1, 2, 3)
+	result, _, err := client.Talks.CreateTalk(context.Background(), topicID, talkName, 1, 2, 3)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -44,11 +44,11 @@ func Test_TalksService_CreateTalk_should_create_a_talk(t *testing.T) {
 func Test_TalksService_UpdateTalk_should_update_a_talk_name(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	talkId := 1
+	topicID := 1
+	talkID := 1
 	talkName := "test"
 	b, _ := ioutil.ReadFile(fixturesPath + "update-talk.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d", topicId, talkId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d", topicID, talkID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPut)
 			TestQueryValues(t, r, Values{
@@ -57,7 +57,7 @@ func Test_TalksService_UpdateTalk_should_update_a_talk_name(t *testing.T) {
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Talks.UpdateTalk(context.Background(), topicId, talkId, talkName)
+	result, _, err := client.Talks.UpdateTalk(context.Background(), topicID, talkID, talkName)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -71,16 +71,16 @@ func Test_TalksService_UpdateTalk_should_update_a_talk_name(t *testing.T) {
 func Test_TalksService_DeleteTalk_should_delete_a_talk(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	talkId := 1
+	topicID := 1
+	talkID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "update-talk.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d", topicId, talkId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d", topicID, talkID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Talks.DeleteTalk(context.Background(), topicId, talkId)
+	result, _, err := client.Talks.DeleteTalk(context.Background(), topicID, talkID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -94,15 +94,15 @@ func Test_TalksService_DeleteTalk_should_delete_a_talk(t *testing.T) {
 func Test_TalksService_GetTalkList_should_get_talk_list(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "get-talk-list.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Talks.GetTalkList(context.Background(), topicId)
+	result, _, err := client.Talks.GetTalkList(context.Background(), topicID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -118,10 +118,10 @@ func Test_TalksService_GetTalkList_should_get_talk_list(t *testing.T) {
 func Test_TalksService_GetMessagesInTalk_should_get_some_messages_in_talk(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	talkId := 1
+	topicID := 1
+	talkID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "get-messages-in-talk.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicId, talkId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicID, talkID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
@@ -132,7 +132,7 @@ func Test_TalksService_GetMessagesInTalk_should_get_some_messages_in_talk(t *tes
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Talks.GetMessagesInTalk(context.Background(), topicId, talkId, &GetMessagesOptions{10, 3, "forward"})
+	result, _, err := client.Talks.GetMessagesInTalk(context.Background(), topicID, talkID, &GetMessagesOptions{10, 3, "forward"})
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -146,10 +146,10 @@ func Test_TalksService_GetMessagesInTalk_should_get_some_messages_in_talk(t *tes
 func Test_TalksService_AddMessageToTalk_should_add_some_messages_to_talk(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	talkId := 1
+	topicID := 1
+	talkID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "add-messages-to-talk.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicId, talkId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicID, talkID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
@@ -160,7 +160,7 @@ func Test_TalksService_AddMessageToTalk_should_add_some_messages_to_talk(t *test
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Talks.AddMessagesToTalk(context.Background(), topicId, talkId, 1, 2, 3)
+	result, _, err := client.Talks.AddMessagesToTalk(context.Background(), topicID, talkID, 1, 2, 3)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -174,10 +174,10 @@ func Test_TalksService_AddMessageToTalk_should_add_some_messages_to_talk(t *test
 func Test_TalksService_RemoveMessagesFromTalk_should_remove_some_messages_from_talk(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	talkId := 1
+	topicID := 1
+	talkID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "remove-messages-from-talk.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicId, talkId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/talks/%d/posts", topicID, talkID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodDelete)
 			TestQueryValues(t, r, Values{
@@ -188,7 +188,7 @@ func Test_TalksService_RemoveMessagesFromTalk_should_remove_some_messages_from_t
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Talks.RemoveMessagesFromTalk(context.Background(), topicId, talkId, 1, 2, 3)
+	result, _, err := client.Talks.RemoveMessagesFromTalk(context.Background(), topicID, talkID, 1, 2, 3)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}

--- a/typetalk/v1/topics.go
+++ b/typetalk/v1/topics.go
@@ -70,6 +70,8 @@ type CreateTopicOptions struct {
 	AddGroupIds   []int  `json:"addGroupIds[%d],omitempty"`
 }
 
+// CreateTopic creates a topic.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/create-topic
 func (s *TopicsService) CreateTopic(ctx context.Context, opt *CreateTopicOptions) (*TopicDetails, *shared.Response, error) {
 	u := "topics"
@@ -86,9 +88,11 @@ type UpdateTopicOptions struct {
 	Description string `json:"description,omitempty"`
 }
 
+// UpdateTopic updates a topic.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-topic
-func (s *TopicsService) UpdateTopic(ctx context.Context, topicId int, opt *UpdateTopicOptions) (*TopicDetails, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d", topicId)
+func (s *TopicsService) UpdateTopic(ctx context.Context, topicID int, opt *UpdateTopicOptions) (*TopicDetails, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d", topicID)
 	var result *TopicDetails
 	resp, err := s.client.Put(ctx, u, opt, &result)
 	if err != nil {
@@ -97,9 +101,11 @@ func (s *TopicsService) UpdateTopic(ctx context.Context, topicId int, opt *Updat
 	return result, resp, nil
 }
 
+// DeleteTopic deletes a topic.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-topic
-func (s *TopicsService) DeleteTopic(ctx context.Context, topicId int) (*Topic, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d", topicId)
+func (s *TopicsService) DeleteTopic(ctx context.Context, topicID int) (*Topic, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d", topicID)
 	var result *Topic
 	resp, err := s.client.Delete(ctx, u, &result)
 	if err != nil {
@@ -108,9 +114,11 @@ func (s *TopicsService) DeleteTopic(ctx context.Context, topicId int) (*Topic, *
 	return result, resp, nil
 }
 
+// GetTopicDetails fetches a topic's detailed information.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-topic-details
-func (s *TopicsService) GetTopicDetails(ctx context.Context, topicId int) (*TopicDetails, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d", topicId)
+func (s *TopicsService) GetTopicDetails(ctx context.Context, topicID int) (*TopicDetails, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d", topicID)
 	var result *TopicDetails
 	resp, err := s.client.Get(ctx, u, &result)
 	if err != nil {
@@ -125,9 +133,11 @@ type GetTopicMessagesOptions struct {
 	Direction string `json:"direction,omitempty"`
 }
 
+// GetTopicMessages fetches messages list in a topic.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-messages
-func (s *TopicsService) GetTopicMessages(ctx context.Context, topicId int, opt *GetTopicMessagesOptions) (*TopicMessages, *shared.Response, error) {
-	u, err := internal.AddQueries(fmt.Sprintf("topics/%d", topicId), opt)
+func (s *TopicsService) GetTopicMessages(ctx context.Context, topicID int, opt *GetTopicMessagesOptions) (*TopicMessages, *shared.Response, error) {
+	u, err := internal.AddQueries(fmt.Sprintf("topics/%d", topicID), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -144,14 +154,16 @@ type UpdateTopicMembersOptions struct {
 	AddGroupIds                         []int    `json:"addGroupIds[%d],omitempty"`
 	InvitationsEmail                    []string `json:"invitations[%d].email,omitempty"`
 	InvitationsRole                     []string `json:"invitations[%d].role,omitempty"`
-	RemoveAccountsId                    []int    `json:"removeAccounts[%d].id,omitempty"`
+	RemoveAccountsID                    []int    `json:"removeAccounts[%d].id,omitempty"`
 	RemoveAccountsCancelSpaceInvitation []bool   `json:"removeAccounts[%d].cancelSpaceInvitation,omitempty"`
 	RemoveGroupIds                      []bool   `json:"removeGroupIds[%d],omitempty"`
 }
 
+// UpdateTopicMembers updates members in a topic.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-topic-members
-func (s *TopicsService) UpdateTopicMembers(ctx context.Context, topicId int, opt *UpdateTopicMembersOptions) (*TopicDetails, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/members/update", topicId)
+func (s *TopicsService) UpdateTopicMembers(ctx context.Context, topicID int, opt *UpdateTopicMembersOptions) (*TopicDetails, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/members/update", topicID)
 	var result *TopicDetails
 	resp, err := s.client.Post(ctx, u, opt, &result)
 	if err != nil {
@@ -160,9 +172,11 @@ func (s *TopicsService) UpdateTopicMembers(ctx context.Context, topicId int, opt
 	return result, resp, nil
 }
 
+// FavoriteTopic marks a topic as favorite.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/favorite-topic
-func (s *TopicsService) FavoriteTopic(ctx context.Context, topicId int) (*FavoriteTopic, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/favorite", topicId)
+func (s *TopicsService) FavoriteTopic(ctx context.Context, topicID int) (*FavoriteTopic, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/favorite", topicID)
 	var result *FavoriteTopic
 	resp, err := s.client.Post(ctx, u, nil, &result)
 	if err != nil {
@@ -171,9 +185,11 @@ func (s *TopicsService) FavoriteTopic(ctx context.Context, topicId int) (*Favori
 	return result, resp, nil
 }
 
+// UnfavoriteTopic marks a topic as unfavorite.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/unfavorite-topic
-func (s *TopicsService) UnfavoriteTopic(ctx context.Context, topicId int) (*FavoriteTopic, *shared.Response, error) {
-	u := fmt.Sprintf("topics/%d/favorite", topicId)
+func (s *TopicsService) UnfavoriteTopic(ctx context.Context, topicID int) (*FavoriteTopic, *shared.Response, error) {
+	u := fmt.Sprintf("topics/%d/favorite", topicID)
 	var result *FavoriteTopic
 	resp, err := s.client.Delete(ctx, u, &result)
 	if err != nil {
@@ -187,9 +203,11 @@ type readMessagesInTopicOptions struct {
 	PostID  int `json:"postId,omitempty"`
 }
 
+// ReadMessagesInTopic mark a message as read.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/save-read-topic
-func (s *TopicsService) ReadMessagesInTopic(ctx context.Context, topicId, postId int) (*Unread, *shared.Response, error) {
-	u, err := internal.AddQueries("bookmarks", &readMessagesInTopicOptions{topicId, postId})
+func (s *TopicsService) ReadMessagesInTopic(ctx context.Context, topicID, postID int) (*Unread, *shared.Response, error) {
+	u, err := internal.AddQueries("bookmarks", &readMessagesInTopicOptions{topicID, postID})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -203,6 +221,8 @@ func (s *TopicsService) ReadMessagesInTopic(ctx context.Context, topicId, postId
 	return result.Unread, resp, nil
 }
 
+// GetMyTopics fetches topics list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-topics
 func (s *TopicsService) GetMyTopics(ctx context.Context) ([]*FavoriteTopicWithUnread, *shared.Response, error) {
 	u := "topics"

--- a/typetalk/v1/topics_test.go
+++ b/typetalk/v1/topics_test.go
@@ -45,9 +45,9 @@ func Test_TopicsService_CreateTopic_should_create_a_topic(t *testing.T) {
 func Test_TopicsService_UpdateTopic_should_update_a_topic(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "update-topic.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPut)
 			TestFormValues(t, r, Values{
@@ -57,7 +57,7 @@ func Test_TopicsService_UpdateTopic_should_update_a_topic(t *testing.T) {
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.UpdateTopic(context.Background(), topicId, &UpdateTopicOptions{"nulab", "This is a test topic."})
+	result, _, err := client.Topics.UpdateTopic(context.Background(), topicID, &UpdateTopicOptions{"nulab", "This is a test topic."})
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -71,15 +71,15 @@ func Test_TopicsService_UpdateTopic_should_update_a_topic(t *testing.T) {
 func Test_TopicsService_DeleteTopic_should_delete_a_topic(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "delete-topic.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.DeleteTopic(context.Background(), topicId)
+	result, _, err := client.Topics.DeleteTopic(context.Background(), topicID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -93,15 +93,15 @@ func Test_TopicsService_DeleteTopic_should_delete_a_topic(t *testing.T) {
 func Test_TopicsService_GetTopicDetails_should_get_a_topic_details(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "get-topic-details.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.GetTopicDetails(context.Background(), topicId)
+	result, _, err := client.Topics.GetTopicDetails(context.Background(), topicID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -115,9 +115,9 @@ func Test_TopicsService_GetTopicDetails_should_get_a_topic_details(t *testing.T)
 func Test_TopicsService_GetTopicMessages_should_get_some_topic_messages(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "get-topic-messages.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodGet)
 			TestQueryValues(t, r, Values{
@@ -128,7 +128,7 @@ func Test_TopicsService_GetTopicMessages_should_get_some_topic_messages(t *testi
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.GetTopicMessages(context.Background(), topicId, &GetTopicMessagesOptions{10, 3, "backward"})
+	result, _, err := client.Topics.GetTopicMessages(context.Background(), topicID, &GetTopicMessagesOptions{10, 3, "backward"})
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -142,9 +142,9 @@ func Test_TopicsService_GetTopicMessages_should_get_some_topic_messages(t *testi
 func Test_TopicsService_UpdateTopicMembers_should_add_some_topic_members(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "update-topic-members.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/members/update", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/members/update", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPost)
 			TestFormValues(t, r, Values{
@@ -159,14 +159,14 @@ func Test_TopicsService_UpdateTopicMembers_should_add_some_topic_members(t *test
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.UpdateTopicMembers(context.Background(), topicId, &UpdateTopicMembersOptions{
+	result, _, err := client.Topics.UpdateTopicMembers(context.Background(), topicID, &UpdateTopicMembersOptions{
 		AddAccountIds: []int{1},
 		AddGroupIds:   []int{1},
 		InvitationsEmail: []string{
 			"example1@nulab-inc.com",
 		},
 		InvitationsRole:                     []string{"Admin"},
-		RemoveAccountsId:                    []int{4},
+		RemoveAccountsID:                    []int{4},
 		RemoveAccountsCancelSpaceInvitation: []bool{true},
 		RemoveGroupIds:                      []bool{true},
 	})
@@ -183,15 +183,15 @@ func Test_TopicsService_UpdateTopicMembers_should_add_some_topic_members(t *test
 func Test_TopicsService_FavoriteTopic_should_favorite_topic(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "favorite-topic.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/favorite", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/favorite", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodPost)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.FavoriteTopic(context.Background(), topicId)
+	result, _, err := client.Topics.FavoriteTopic(context.Background(), topicID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -205,15 +205,15 @@ func Test_TopicsService_FavoriteTopic_should_favorite_topic(t *testing.T) {
 func Test_TopicsService_UnfavoriteTopic_should_unfavorite_topic(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
+	topicID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "unfavorite-topic.json")
-	mux.HandleFunc(fmt.Sprintf("/topics/%d/favorite", topicId),
+	mux.HandleFunc(fmt.Sprintf("/topics/%d/favorite", topicID),
 		func(w http.ResponseWriter, r *http.Request) {
 			TestMethod(t, r, http.MethodDelete)
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.UnfavoriteTopic(context.Background(), topicId)
+	result, _, err := client.Topics.UnfavoriteTopic(context.Background(), topicID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}
@@ -227,8 +227,8 @@ func Test_TopicsService_UnfavoriteTopic_should_unfavorite_topic(t *testing.T) {
 func Test_TopicsService_ReadMessagesInTopic_should_read_some_messages_in_topic(t *testing.T) {
 	setup()
 	defer teardown()
-	topicId := 1
-	postId := 1
+	topicID := 1
+	postID := 1
 	b, _ := ioutil.ReadFile(fixturesPath + "read-messages-in-topic.json")
 	mux.HandleFunc("/bookmarks",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -240,7 +240,7 @@ func Test_TopicsService_ReadMessagesInTopic_should_read_some_messages_in_topic(t
 			fmt.Fprint(w, string(b))
 		})
 
-	result, _, err := client.Topics.ReadMessagesInTopic(context.Background(), topicId, postId)
+	result, _, err := client.Topics.ReadMessagesInTopic(context.Background(), topicID, postID)
 	if err != nil {
 		t.Errorf("Returned error: %v", err)
 	}

--- a/typetalk/v1/v1.go
+++ b/typetalk/v1/v1.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ApiVersion = "v1"
+	APIVersion = "v1"
 )
 
 type service struct {
@@ -38,7 +38,7 @@ func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	baseURL, _ := url.Parse(internal.DefaultBaseURL + ApiVersion + "/")
+	baseURL, _ := url.Parse(internal.DefaultBaseURL + APIVersion + "/")
 
 	c := &Client{client: &internal.ClientCore{Client: httpClient, BaseURL: baseURL, UserAgent: internal.UserAgent}}
 

--- a/typetalk/v2/likes.go
+++ b/typetalk/v2/likes.go
@@ -96,6 +96,8 @@ type getLikesOptions struct {
 	SpaceKey string `json:"spaceKey"`
 }
 
+// GetLikesReceive fetches received likes list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-receive/
 func (s *LikesService) GetLikesReceive(ctx context.Context, spaceKey string, opt *GetLikesOptions) ([]*ReceiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/receive", &getLikesOptions{GetLikesOptions: opt, SpaceKey: spaceKey})
@@ -112,6 +114,8 @@ func (s *LikesService) GetLikesReceive(ctx context.Context, spaceKey string, opt
 	return result.LikedPosts, resp, nil
 }
 
+// GetLikesGive fetches given likes list. Those likes are given by your accounts.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-give/
 func (s *LikesService) GetLikesGive(ctx context.Context, spaceKey string, opt *GetLikesOptions) ([]*GiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/give", &getLikesOptions{GetLikesOptions: opt, SpaceKey: spaceKey})
@@ -128,6 +132,8 @@ func (s *LikesService) GetLikesGive(ctx context.Context, spaceKey string, opt *G
 	return result.GiveLikedPost, resp, nil
 }
 
+// GetLikesDiscover fetches given likes list. Those likes are given by other accounts.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-discover/
 func (s *LikesService) GetLikesDiscover(ctx context.Context, spaceKey string, opt *GetLikesOptions) ([]*DiscoverLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/discover", &getLikesOptions{GetLikesOptions: opt, SpaceKey: spaceKey})
@@ -145,7 +151,7 @@ func (s *LikesService) GetLikesDiscover(ctx context.Context, spaceKey string, op
 }
 
 type ReadReceivedLikesOptions struct {
-	LikeId int `json:"likeId,omitempty"`
+	LikeID int `json:"likeId,omitempty"`
 }
 
 type readReceivedLikesOptions struct {
@@ -162,6 +168,8 @@ type ReadReceivedLikesResult struct {
 	} `json:"like"`
 }
 
+// ReadReceivedLikes marks likes as read.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/save-read-likes/
 func (s *LikesService) ReadReceivedLikes(ctx context.Context, spaceKey string, opt *ReadReceivedLikesOptions) (*ReadReceivedLikesResult, *shared.Response, error) {
 	u := "likes/receive/bookmark/save"

--- a/typetalk/v2/mentions.go
+++ b/typetalk/v2/mentions.go
@@ -26,6 +26,8 @@ type getMentionListOptions struct {
 	SpaceKey string `json:"spaceKey"`
 }
 
+// GetMentionList fetches mentions list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-mentions
 func (s *MentionsService) GetMentionList(ctx context.Context, spaceKey string, opt *GetMentionListOptions) ([]*Mention, *shared.Response, error) {
 	u, err := internal.AddQueries("mentions", &getMentionListOptions{opt, spaceKey})

--- a/typetalk/v2/messages.go
+++ b/typetalk/v2/messages.go
@@ -74,6 +74,8 @@ type GetMessagesOptions struct {
 	Direction string `json:"direction,omitempty"`
 }
 
+// GetDirectMessages fetches direct messages.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-direct-messages
 func (s *MessagesService) GetDirectMessages(ctx context.Context, spaceKey, accountName string, opt *GetMessagesOptions) (*DirectMessages, *shared.Response, error) {
 	u, err := internal.AddQueries(fmt.Sprintf("spaces/%s/messages/@%s", spaceKey, accountName), opt)
@@ -88,6 +90,8 @@ func (s *MessagesService) GetDirectMessages(ctx context.Context, spaceKey, accou
 	return result, resp, nil
 }
 
+// PostDirectMessage posts direct message.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/post-direct-message
 func (s *MessagesService) PostDirectMessage(ctx context.Context, spaceKey, accountName, message string, opt *PostMessageOptions) (*PostedMessageResult, *shared.Response, error) {
 	u := fmt.Sprintf("spaces/%s/messages/@%s", spaceKey, accountName)
@@ -102,6 +106,8 @@ func (s *MessagesService) PostDirectMessage(ctx context.Context, spaceKey, accou
 	return result, resp, nil
 }
 
+// SearchMessages searches messages.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/search-messages/
 func (s *MessagesService) SearchMessages(ctx context.Context, spaceKey, q string, opt *SearchMessagesOptions) (*SearchMessagesResult, *shared.Response, error) {
 	u, err := internal.AddQueries("search/posts", &searchMessagesOptions{SearchMessagesOptions: opt, SpaceKey: spaceKey, Q: q})

--- a/typetalk/v2/notifications.go
+++ b/typetalk/v2/notifications.go
@@ -86,6 +86,8 @@ type Scheduled struct {
 	End     string `json:"end"`
 }
 
+// GetNotificationCount fetches notification counts.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-notification-status
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *shared.Response, error) {
 	u := "notifications/status"
@@ -97,6 +99,8 @@ func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*Notif
 	return result, resp, nil
 }
 
+// ReadNotification marks notifications as read.
+//
 // Deprecated: Use ReadNotification in github.com/nulab/go-typetalk/typetalk/v3
 func (s *NotificationsService) ReadNotification(ctx context.Context) (*ReadNotificationResult, *shared.Response, error) {
 	u := "notifications"

--- a/typetalk/v2/topics.go
+++ b/typetalk/v2/topics.go
@@ -45,6 +45,8 @@ type DirectMessageTopic struct {
 	DirectMessage *DirectMessage `json:"directMessage"`
 }
 
+// GetMyTopics fetches topics list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-topics/
 func (s *TopicsService) GetMyTopics(ctx context.Context, spaceKey string) ([]*FavoriteTopicWithUnread, *shared.Response, error) {
 	u, err := internal.AddQueries("topics", &getMyTopicsOptions{spaceKey})
@@ -61,6 +63,8 @@ func (s *TopicsService) GetMyTopics(ctx context.Context, spaceKey string) ([]*Fa
 	return result.Topics, resp, nil
 }
 
+// GetMyDirectMessageTopics fetches direct message topics list.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-dm-topics
 func (s *MessagesService) GetMyDirectMessageTopics(ctx context.Context, spaceKey string) ([]*DirectMessageTopic, *shared.Response, error) {
 	u, err := internal.AddQueries("messages", &getMyTopicsOptions{spaceKey})

--- a/typetalk/v2/v2.go
+++ b/typetalk/v2/v2.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ApiVersion = "v2"
+	APIVersion = "v2"
 )
 
 type service struct {
@@ -34,7 +34,7 @@ func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	baseURL, _ := url.Parse(internal.DefaultBaseURL + ApiVersion + "/")
+	baseURL, _ := url.Parse(internal.DefaultBaseURL + APIVersion + "/")
 
 	c := &Client{client: &internal.ClientCore{Client: httpClient, BaseURL: baseURL, UserAgent: internal.UserAgent}}
 

--- a/typetalk/v3/accounts.go
+++ b/typetalk/v3/accounts.go
@@ -32,6 +32,8 @@ type getMyFriendsOptions struct {
 	Q        string `json:"q"`
 }
 
+// GetMyFriends searches accounts.
+//
 // Deprecated: Use GetMyFrieands in github.com/nulab/go-typetalk/typetalk/v4
 func (s *AccountsService) GetMyFriends(ctx context.Context, spaceKey, q string, opt *GetMyFriendsOptions) ([]*Account, *shared.Response, error) {
 	u, err := internal.AddQueries("search/friends", &getMyFriendsOptions{GetMyFriendsOptions: opt, SpaceKey: spaceKey, Q: q})

--- a/typetalk/v3/notifications.go
+++ b/typetalk/v3/notifications.go
@@ -28,6 +28,8 @@ type readNotificationOptions struct {
 	SpaceKey string `json:"spaceKey"`
 }
 
+// ReadNotification marks notifications as read.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/3/open-notification
 func (s *NotificationsService) ReadNotification(ctx context.Context, spaceKey string) (*ReadNotificationResult, *shared.Response, error) {
 	u := "notifications"

--- a/typetalk/v3/v3.go
+++ b/typetalk/v3/v3.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ApiVersion = "v3"
+	APIVersion = "v3"
 )
 
 type service struct {
@@ -31,7 +31,7 @@ func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	baseURL, _ := url.Parse(internal.DefaultBaseURL + ApiVersion + "/")
+	baseURL, _ := url.Parse(internal.DefaultBaseURL + APIVersion + "/")
 
 	c := &Client{client: &internal.ClientCore{Client: httpClient, BaseURL: baseURL, UserAgent: internal.UserAgent}}
 

--- a/typetalk/v4/accounts.go
+++ b/typetalk/v4/accounts.go
@@ -48,6 +48,8 @@ type getMyFriendsOptions struct {
 	Q        string `json:"q"`
 }
 
+// GetMyFriends searches accounts.
+//
 // https://developer.nulab-inc.com/docs/typetalk/api/4/get-friends
 func (s *AccountsService) GetMyFriends(ctx context.Context, spaceKey, q string, opt *GetMyFriendsOptions) (*Friends, *shared.Response, error) {
 	u, err := internal.AddQueries("search/friends", &getMyFriendsOptions{GetMyFriendsOptions: opt, SpaceKey: spaceKey, Q: q})

--- a/typetalk/v4/v4.go
+++ b/typetalk/v4/v4.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ApiVersion = "v4"
+	APIVersion = "v4"
 )
 
 type service struct {
@@ -30,7 +30,7 @@ func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	baseURL, _ := url.Parse(internal.DefaultBaseURL + ApiVersion + "/")
+	baseURL, _ := url.Parse(internal.DefaultBaseURL + APIVersion + "/")
 
 	c := &Client{client: &internal.ClientCore{Client: httpClient, BaseURL: baseURL, UserAgent: internal.UserAgent}}
 

--- a/typetalk/v5/notifications.go
+++ b/typetalk/v5/notifications.go
@@ -86,6 +86,8 @@ type Scheduled struct {
 	End     string `json:"end"`
 }
 
+// GetNotificationCount fetches notification counts.
+//
 // Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/5/get-notification-status/
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *shared.Response, error) {
 	u := "notifications/status"

--- a/typetalk/v5/v5.go
+++ b/typetalk/v5/v5.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	ApiVersion = "v5"
+	APIVersion = "v5"
 )
 
 type service struct {
@@ -30,7 +30,7 @@ func NewClient(httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	baseURL, _ := url.Parse(internal.DefaultBaseURL + ApiVersion + "/")
+	baseURL, _ := url.Parse(internal.DefaultBaseURL + APIVersion + "/")
 
 	c := &Client{client: &internal.ClientCore{Client: httpClient, BaseURL: baseURL, UserAgent: internal.UserAgent}}
 


### PR DESCRIPTION
Fixed "should be..." warnings. Could you review it, please? :pray:

```
$ golint ./... | grep "should be"
example/access_token/main.go:13:2: var topicId should be topicID
tests/integration/typetalk_test.go:26:2: var topicId should be topicID
tests/integration/typetalk_test.go:27:2: var postId should be postID
tests/integration/typetalk_test.go:40:2: var clientId should be clientID
typetalk/v1/accounts.go:22:2: struct field TimezoneId should be TimezoneID
typetalk/v1/accounts.go:60:1: comment on exported method AccountsService.GetMyProfile should be of the form "GetMyProfile ..."
...
```