### PR TITLE
Updated golint path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ endif
 .PHONY: devel-deps
 devel-deps:
 	go get ${u} github.com/mattn/goveralls
-	go get ${u} github.com/golang/lint/golint
+	go get ${u} golang.org/x/lint/golint
 	go get ${u} github.com/motemen/gobump/cmd/gobump
 	go get ${u} github.com/Songmu/ghch/cmd/ghch
 


### PR DESCRIPTION
Fixes https://github.com/nulab/go-typetalk/issues/55

```
horie at IH-20170901-002 in ~/src/github.com/nulab/go-typetalk on update-golint-url
$ make devel-deps
go get  github.com/mattn/goveralls
go get  golang.org/x/lint/golint
go get  github.com/motemen/gobump/cmd/gobump
go get  github.com/Songmu/ghch/cmd/ghch
```