### PR TITLE
Uses nulab.com for API docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ go-typetalk
 [coveralls]: https://coveralls.io/github/nulab/go-typetalk?branch=master
 [godocs]: http://godoc.org/github.com/nulab/go-typetalk
 
-go-typetalk is a GO client library for accessing the [Typetalk API](http://developer.nulab-inc.com/docs/typetalk).
+go-typetalk is a GO client library for accessing the [Typetalk API](https://developer.nulab.com/docs/typetalk).
 
 ## Prerequisite
 
-To use this library, you must have a valid [client id and client secret](https://developer.nulab-inc.com/docs/typetalk/auth#oauth2) provided by Typetalk and register a new client application. Or you can use the [Typetalk Token](https://developer.nulab-inc.com/docs/typetalk/auth#tttoken).
+To use this library, you must have a valid [client id and client secret](https://developer.nulab.com/docs/typetalk/auth#oauth2) provided by Typetalk and register a new client application. Or you can use the [Typetalk Token](https://developer.nulab.com/docs/typetalk/auth#tttoken).
 
 ## Usage
 

--- a/testdata/v2/get-notification-count.json
+++ b/testdata/v2/get-notification-count.json
@@ -6,7 +6,7 @@
           "key": "xxxxxxxxx",
           "name": "Awesome Tech Inc.",
           "enabled": true,
-          "imageUrl": "https://dev.apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
+          "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
         },
         "myRole": "ADMIN",
         "isPaymentAdmin": true,
@@ -34,7 +34,7 @@
         "key": "xxxxxxxxx",
         "name": "Awesome Tech Inc.",
         "enabled": true,
-        "imageUrl": "https://dev.apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
+        "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
       },
       "access": {
         "unopened": 0,
@@ -56,7 +56,7 @@
           "key": "xxxxxxxxx",
           "name": "Example Organization",
           "enabled": true,
-          "imageUrl": "https://dev.apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
+          "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
         },
         "myRole": "ADMIN",
         "isPaymentAdmin": true,
@@ -87,7 +87,7 @@
         "key": "xxxxxxxxx",
         "name": "Example Organization",
         "enabled": true,
-        "imageUrl": "https://dev.apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
+        "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
       },
       "access": {
         "unopened": 0,
@@ -109,7 +109,7 @@
           "key": "xxxxxxxxx",
           "name": "Fabulous Tech Inc.",
           "enabled": true,
-          "imageUrl": "https://dev.apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
+          "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
         },
         "myRole": "ADMIN",
         "isPaymentAdmin": true,
@@ -137,7 +137,7 @@
         "key": "xxxxxxxxx",
         "name": "Fabulous Tech Inc.",
         "enabled": true,
-        "imageUrl": "https://dev.apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
+        "imageUrl": "https://apps.nulab-inc.com/spaces/xxxxxxxxx/photo/large"
       },
       "access": {
         "unopened": 0,

--- a/typetalk/v1/accounts.go
+++ b/typetalk/v1/accounts.go
@@ -67,7 +67,7 @@ type OnlineStatus struct {
 
 // GetMyProfile fetches the user's account information.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-profile
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-profile
 func (s *AccountsService) GetMyProfile(ctx context.Context) (*MyProfile, *shared.Response, error) {
 	u := "profile"
 	var result *MyProfile
@@ -80,7 +80,7 @@ func (s *AccountsService) GetMyProfile(ctx context.Context) (*MyProfile, *shared
 
 // GetFriendProfile fetches other user's account information.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-friend-profile
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-friend-profile
 func (s *AccountsService) GetFriendProfile(ctx context.Context, accountName string) (*Profile, *shared.Response, error) {
 	u := fmt.Sprintf("profile/%s", accountName)
 	var result *Profile
@@ -140,7 +140,7 @@ type getOnlineStatusOptions struct {
 
 // GetOnlineStatus fetches an user's online status.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-online-status
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-online-status
 func (s *AccountsService) GetOnlineStatus(ctx context.Context, accountIds ...int) (*OnlineStatus, *shared.Response, error) {
 	u, err := internal.AddQueries("accounts/status", &getOnlineStatusOptions{accountIds})
 	if err != nil {

--- a/typetalk/v1/files.go
+++ b/typetalk/v1/files.go
@@ -23,7 +23,7 @@ type AttachmentFile struct {
 
 // UploadAttachmentFile uploads attachment file.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/upload-attachment
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/upload-attachment
 func (s *FilesService) UploadAttachmentFile(ctx context.Context, topicID int, file *os.File) (*AttachmentFile, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%v/attachments", topicID)
 	stat, err := file.Stat()
@@ -51,7 +51,7 @@ func (s *FilesService) UploadAttachmentFile(ctx context.Context, topicID int, fi
 
 // DownloadAttachmentFile downloads attachment file.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/download-attachment
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/download-attachment
 func (s *FilesService) DownloadAttachmentFile(ctx context.Context, topicID, postID, attachmentID int, filename string) (io.ReadCloser, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d/attachments/%d/%s", topicID, postID, attachmentID, filename)
 

--- a/typetalk/v1/likes.go
+++ b/typetalk/v1/likes.go
@@ -41,7 +41,7 @@ type GetLikesOptions struct {
 
 // GetLikesReceive fetches received likes list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-receive/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-likes-receive/
 func (s *LikesService) GetLikesReceive(ctx context.Context, opt *GetLikesOptions) ([]*ReceiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/receive", opt)
 	if err != nil {
@@ -59,7 +59,7 @@ func (s *LikesService) GetLikesReceive(ctx context.Context, opt *GetLikesOptions
 
 // GetLikesGive fetches given likes list. Those likes are given by your account.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-give/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-likes-give/
 func (s *LikesService) GetLikesGive(ctx context.Context, opt *GetLikesOptions) ([]*GiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/give", opt)
 	if err != nil {
@@ -77,7 +77,7 @@ func (s *LikesService) GetLikesGive(ctx context.Context, opt *GetLikesOptions) (
 
 // GetLikesDiscover fetches given likes list. Those likes are given by all the accounts.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-likes-discover/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-likes-discover/
 func (s *LikesService) GetLikesDiscover(ctx context.Context, opt *GetLikesOptions) ([]*DiscoverLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/discover", opt)
 	if err != nil {
@@ -108,7 +108,7 @@ type ReadReceivedLikesResult struct {
 
 // ReadReceivedLikes marks likes as read.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/save-read-likes/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/save-read-likes/
 func (s *LikesService) ReadReceivedLikes(ctx context.Context, likeID int) (*ReadReceivedLikesResult, *shared.Response, error) {
 	u := "likes/receive/bookmark/save"
 

--- a/typetalk/v1/mentions.go
+++ b/typetalk/v1/mentions.go
@@ -19,7 +19,7 @@ type Mention struct {
 
 // ReadMention marks a mention as read.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/save-read-mention
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/save-read-mention
 func (s *MentionsService) ReadMention(ctx context.Context, mentionID int) (*Mention, *shared.Response, error) {
 	u := fmt.Sprintf("mentions/%d", mentionID)
 	var result *struct {
@@ -39,7 +39,7 @@ type GetMentionListOptions struct {
 
 // GetMentionList fetches mentions list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-mentions
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-mentions
 func (s *MentionsService) GetMentionList(ctx context.Context, opt *GetMentionListOptions) ([]*Mention, *shared.Response, error) {
 	u, err := internal.AddQueries("mentions", opt)
 	if err != nil {

--- a/typetalk/v1/messages.go
+++ b/typetalk/v1/messages.go
@@ -100,7 +100,7 @@ type postMessageOptions struct {
 
 // PostMessage posts a message.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/post-message
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/post-message
 func (s *MessagesService) PostMessage(ctx context.Context, topicID int, message string, opt *PostMessageOptions) (*PostedMessageResult, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%v", topicID)
 	if opt == nil {
@@ -120,7 +120,7 @@ type updateMessageOptions struct {
 
 // UpdateMessage updates a message.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-message
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/update-message
 func (s *MessagesService) UpdateMessage(ctx context.Context, topicID, postID int, message string) (*UpdatedMessageResult, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d", topicID, postID)
 	var result *UpdatedMessageResult
@@ -133,7 +133,7 @@ func (s *MessagesService) UpdateMessage(ctx context.Context, topicID, postID int
 
 // DeleteMessage deletes a message.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-message
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/delete-message
 func (s *MessagesService) DeleteMessage(ctx context.Context, topicID, postID int) (*Post, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d", topicID, postID)
 	var result *Post
@@ -146,7 +146,7 @@ func (s *MessagesService) DeleteMessage(ctx context.Context, topicID, postID int
 
 // GetMessage gets a message.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-message
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-message
 func (s *MessagesService) GetMessage(ctx context.Context, topicID, postID int) (*Message, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d", topicID, postID)
 	var result *Message
@@ -159,7 +159,7 @@ func (s *MessagesService) GetMessage(ctx context.Context, topicID, postID int) (
 
 // LikeMessage marks a message as liked.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/favorite-topic
+// Typetalk API docs: https://developer.nulab.com/ja/docs/typetalk/api/1/favorite-topic
 func (s *MessagesService) LikeMessage(ctx context.Context, topicID, postID int) (*LikedMessageResult, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d/like", topicID, postID)
 	var result *LikedMessageResult
@@ -172,7 +172,7 @@ func (s *MessagesService) LikeMessage(ctx context.Context, topicID, postID int) 
 
 // UnlikeMessage marks a message as unliked.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/1/unfavorite-topic
+// Typetalk API docs: https://developer.nulab.com/ja/docs/typetalk/api/1/unfavorite-topic
 func (s *MessagesService) UnlikeMessage(ctx context.Context, topicID, postID int) (*Like, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/posts/%d/like", topicID, postID)
 	var result *struct {

--- a/typetalk/v1/notifications.go
+++ b/typetalk/v1/notifications.go
@@ -45,7 +45,7 @@ type NotificationCount struct {
 
 // GetNotificationList fetches notifications list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-notifications
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-notifications
 func (s *NotificationsService) GetNotificationList(ctx context.Context) (*NotificationList, *shared.Response, error) {
 	u := "notifications"
 	var result *NotificationList
@@ -58,7 +58,7 @@ func (s *NotificationsService) GetNotificationList(ctx context.Context) (*Notifi
 
 // GetNotificationCount fetches notification counts.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-notification-status
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-notification-status
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *shared.Response, error) {
 	u := "notifications/status"
 	var result *NotificationCount

--- a/typetalk/v1/organizations.go
+++ b/typetalk/v1/organizations.go
@@ -66,7 +66,7 @@ type organizationsGetOptions struct {
 
 // GetMyOrganizations fetches organizations list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-spaces
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-spaces
 func (s *OrganizationsService) GetMyOrganizations(ctx context.Context, excludesGuest bool) ([]*Organization, *shared.Response, error) {
 	u, err := internal.AddQueries("spaces", &organizationsGetOptions{excludesGuest})
 	if err != nil {
@@ -84,7 +84,7 @@ func (s *OrganizationsService) GetMyOrganizations(ctx context.Context, excludesG
 
 // GetOrganizationMembers fetches an organization's members list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-space-members
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-space-members
 func (s *OrganizationsService) GetOrganizationMembers(ctx context.Context, spaceKey string) (*OrganizationMembers, *shared.Response, error) {
 	u := fmt.Sprintf("spaces/%s/members", spaceKey)
 	var result *OrganizationMembers

--- a/typetalk/v1/talks.go
+++ b/typetalk/v1/talks.go
@@ -52,7 +52,7 @@ type CreateTalkOptions struct {
 
 // CreateTalk creates a talk.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/create-talk
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/create-talk
 func (s *TalksService) CreateTalk(ctx context.Context, topicID int, talkName string, postIds ...int) (*CreatedTalkResult, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/talks", topicID)
 	var result *CreatedTalkResult
@@ -69,7 +69,7 @@ type updateTalkOptions struct {
 
 // UpdateTalk updates a talk.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-talk
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/update-talk
 func (s *TalksService) UpdateTalk(ctx context.Context, topicID, talkID int, talkName string) (*UpdatedTalkResult, *shared.Response, error) {
 	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d", topicID, talkID), &updateTalkOptions{talkName})
 	if err != nil {
@@ -86,7 +86,7 @@ func (s *TalksService) UpdateTalk(ctx context.Context, topicID, talkID int, talk
 
 // DeleteTalk deletes a talk.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-talk
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/delete-talk
 func (s *TalksService) DeleteTalk(ctx context.Context, topicID, talkID int) (*DeletedTalkResult, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/talks/%d", topicID, talkID)
 	var result *DeletedTalkResult
@@ -99,7 +99,7 @@ func (s *TalksService) DeleteTalk(ctx context.Context, topicID, talkID int) (*De
 
 // GetTalkList fetches talks list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-talks
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-talks
 func (s *TalksService) GetTalkList(ctx context.Context, topicID int) ([]*Talk, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/talks", topicID)
 	var result *struct {
@@ -114,7 +114,7 @@ func (s *TalksService) GetTalkList(ctx context.Context, topicID int) ([]*Talk, *
 
 // GetMessagesInTalk fetches messages list in a talk.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-talk
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-talk
 func (s *TalksService) GetMessagesInTalk(ctx context.Context, topicID, talkID int, opt *GetMessagesOptions) (*MessagesInTalk, *shared.Response, error) {
 	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d/posts", topicID, talkID), opt)
 	if err != nil {
@@ -134,7 +134,7 @@ type addMessageToTalkOptions struct {
 
 // AddMessagesToTalk adds messages to a talk.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/add-message-to-talk
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/add-message-to-talk
 func (s *TalksService) AddMessagesToTalk(ctx context.Context, topicID, talkID int, postIds ...int) (*MessagesInTalk, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/talks/%d/posts", topicID, talkID)
 	var result *MessagesInTalk
@@ -149,7 +149,7 @@ type removeMessagesFromTalkOptions addMessageToTalkOptions
 
 // RemoveMessagesFromTalk removes messages from a talk.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/remove-message-from-talk
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/remove-message-from-talk
 func (s *TalksService) RemoveMessagesFromTalk(ctx context.Context, topicID, talkID int, postIds ...int) (*RemovedMessagesResult, *shared.Response, error) {
 	u, err := internal.AddQueries(fmt.Sprintf("topics/%d/talks/%d/posts", topicID, talkID), &removeMessagesFromTalkOptions{postIds})
 	if err != nil {

--- a/typetalk/v1/topics.go
+++ b/typetalk/v1/topics.go
@@ -72,7 +72,7 @@ type CreateTopicOptions struct {
 
 // CreateTopic creates a topic.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/create-topic
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/create-topic
 func (s *TopicsService) CreateTopic(ctx context.Context, opt *CreateTopicOptions) (*TopicDetails, *shared.Response, error) {
 	u := "topics"
 	var result *TopicDetails
@@ -90,7 +90,7 @@ type UpdateTopicOptions struct {
 
 // UpdateTopic updates a topic.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-topic
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/update-topic
 func (s *TopicsService) UpdateTopic(ctx context.Context, topicID int, opt *UpdateTopicOptions) (*TopicDetails, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d", topicID)
 	var result *TopicDetails
@@ -103,7 +103,7 @@ func (s *TopicsService) UpdateTopic(ctx context.Context, topicID int, opt *Updat
 
 // DeleteTopic deletes a topic.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/delete-topic
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/delete-topic
 func (s *TopicsService) DeleteTopic(ctx context.Context, topicID int) (*Topic, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d", topicID)
 	var result *Topic
@@ -116,7 +116,7 @@ func (s *TopicsService) DeleteTopic(ctx context.Context, topicID int) (*Topic, *
 
 // GetTopicDetails fetches a topic's detailed information.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-topic-details
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-topic-details
 func (s *TopicsService) GetTopicDetails(ctx context.Context, topicID int) (*TopicDetails, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d", topicID)
 	var result *TopicDetails
@@ -135,7 +135,7 @@ type GetTopicMessagesOptions struct {
 
 // GetTopicMessages fetches messages list in a topic.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-messages
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-messages
 func (s *TopicsService) GetTopicMessages(ctx context.Context, topicID int, opt *GetTopicMessagesOptions) (*TopicMessages, *shared.Response, error) {
 	u, err := internal.AddQueries(fmt.Sprintf("topics/%d", topicID), opt)
 	if err != nil {
@@ -161,7 +161,7 @@ type UpdateTopicMembersOptions struct {
 
 // UpdateTopicMembers updates members in a topic.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/update-topic-members
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/update-topic-members
 func (s *TopicsService) UpdateTopicMembers(ctx context.Context, topicID int, opt *UpdateTopicMembersOptions) (*TopicDetails, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/members/update", topicID)
 	var result *TopicDetails
@@ -174,7 +174,7 @@ func (s *TopicsService) UpdateTopicMembers(ctx context.Context, topicID int, opt
 
 // FavoriteTopic marks a topic as favorite.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/favorite-topic
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/favorite-topic
 func (s *TopicsService) FavoriteTopic(ctx context.Context, topicID int) (*FavoriteTopic, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/favorite", topicID)
 	var result *FavoriteTopic
@@ -187,7 +187,7 @@ func (s *TopicsService) FavoriteTopic(ctx context.Context, topicID int) (*Favori
 
 // UnfavoriteTopic marks a topic as unfavorite.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/unfavorite-topic
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/unfavorite-topic
 func (s *TopicsService) UnfavoriteTopic(ctx context.Context, topicID int) (*FavoriteTopic, *shared.Response, error) {
 	u := fmt.Sprintf("topics/%d/favorite", topicID)
 	var result *FavoriteTopic
@@ -205,7 +205,7 @@ type readMessagesInTopicOptions struct {
 
 // ReadMessagesInTopic mark a message as read.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/save-read-topic
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/save-read-topic
 func (s *TopicsService) ReadMessagesInTopic(ctx context.Context, topicID, postID int) (*Unread, *shared.Response, error) {
 	u, err := internal.AddQueries("bookmarks", &readMessagesInTopicOptions{topicID, postID})
 	if err != nil {
@@ -223,7 +223,7 @@ func (s *TopicsService) ReadMessagesInTopic(ctx context.Context, topicID, postID
 
 // GetMyTopics fetches topics list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/1/get-topics
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/1/get-topics
 func (s *TopicsService) GetMyTopics(ctx context.Context) ([]*FavoriteTopicWithUnread, *shared.Response, error) {
 	u := "topics"
 	var result *struct {

--- a/typetalk/v2/likes.go
+++ b/typetalk/v2/likes.go
@@ -98,7 +98,7 @@ type getLikesOptions struct {
 
 // GetLikesReceive fetches received likes list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-receive/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-likes-receive/
 func (s *LikesService) GetLikesReceive(ctx context.Context, spaceKey string, opt *GetLikesOptions) ([]*ReceiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/receive", &getLikesOptions{GetLikesOptions: opt, SpaceKey: spaceKey})
 	if err != nil {
@@ -116,7 +116,7 @@ func (s *LikesService) GetLikesReceive(ctx context.Context, spaceKey string, opt
 
 // GetLikesGive fetches given likes list. Those likes are given by your accounts.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-give/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-likes-give/
 func (s *LikesService) GetLikesGive(ctx context.Context, spaceKey string, opt *GetLikesOptions) ([]*GiveLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/give", &getLikesOptions{GetLikesOptions: opt, SpaceKey: spaceKey})
 	if err != nil {
@@ -134,7 +134,7 @@ func (s *LikesService) GetLikesGive(ctx context.Context, spaceKey string, opt *G
 
 // GetLikesDiscover fetches given likes list. Those likes are given by other accounts.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-likes-discover/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-likes-discover/
 func (s *LikesService) GetLikesDiscover(ctx context.Context, spaceKey string, opt *GetLikesOptions) ([]*DiscoverLikedPost, *shared.Response, error) {
 	u, err := internal.AddQueries("likes/discover", &getLikesOptions{GetLikesOptions: opt, SpaceKey: spaceKey})
 	if err != nil {
@@ -170,7 +170,7 @@ type ReadReceivedLikesResult struct {
 
 // ReadReceivedLikes marks likes as read.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/save-read-likes/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/save-read-likes/
 func (s *LikesService) ReadReceivedLikes(ctx context.Context, spaceKey string, opt *ReadReceivedLikesOptions) (*ReadReceivedLikesResult, *shared.Response, error) {
 	u := "likes/receive/bookmark/save"
 	var result *ReadReceivedLikesResult

--- a/typetalk/v2/mentions.go
+++ b/typetalk/v2/mentions.go
@@ -28,7 +28,7 @@ type getMentionListOptions struct {
 
 // GetMentionList fetches mentions list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-mentions
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-mentions
 func (s *MentionsService) GetMentionList(ctx context.Context, spaceKey string, opt *GetMentionListOptions) ([]*Mention, *shared.Response, error) {
 	u, err := internal.AddQueries("mentions", &getMentionListOptions{opt, spaceKey})
 	if err != nil {

--- a/typetalk/v2/messages.go
+++ b/typetalk/v2/messages.go
@@ -76,7 +76,7 @@ type GetMessagesOptions struct {
 
 // GetDirectMessages fetches direct messages.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-direct-messages
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-direct-messages
 func (s *MessagesService) GetDirectMessages(ctx context.Context, spaceKey, accountName string, opt *GetMessagesOptions) (*DirectMessages, *shared.Response, error) {
 	u, err := internal.AddQueries(fmt.Sprintf("spaces/%s/messages/@%s", spaceKey, accountName), opt)
 	if err != nil {
@@ -92,7 +92,7 @@ func (s *MessagesService) GetDirectMessages(ctx context.Context, spaceKey, accou
 
 // PostDirectMessage posts direct message.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/post-direct-message
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/post-direct-message
 func (s *MessagesService) PostDirectMessage(ctx context.Context, spaceKey, accountName, message string, opt *PostMessageOptions) (*PostedMessageResult, *shared.Response, error) {
 	u := fmt.Sprintf("spaces/%s/messages/@%s", spaceKey, accountName)
 	if opt == nil {
@@ -108,7 +108,7 @@ func (s *MessagesService) PostDirectMessage(ctx context.Context, spaceKey, accou
 
 // SearchMessages searches messages.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/search-messages/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/search-messages/
 func (s *MessagesService) SearchMessages(ctx context.Context, spaceKey, q string, opt *SearchMessagesOptions) (*SearchMessagesResult, *shared.Response, error) {
 	u, err := internal.AddQueries("search/posts", &searchMessagesOptions{SearchMessagesOptions: opt, SpaceKey: spaceKey, Q: q})
 	if err != nil {

--- a/typetalk/v2/notifications.go
+++ b/typetalk/v2/notifications.go
@@ -88,7 +88,7 @@ type Scheduled struct {
 
 // GetNotificationCount fetches notification counts.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-notification-status
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-notification-status
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *shared.Response, error) {
 	u := "notifications/status"
 	var result *NotificationCount

--- a/typetalk/v2/topics.go
+++ b/typetalk/v2/topics.go
@@ -47,7 +47,7 @@ type DirectMessageTopic struct {
 
 // GetMyTopics fetches topics list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-topics/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-topics/
 func (s *TopicsService) GetMyTopics(ctx context.Context, spaceKey string) ([]*FavoriteTopicWithUnread, *shared.Response, error) {
 	u, err := internal.AddQueries("topics", &getMyTopicsOptions{spaceKey})
 	if err != nil {
@@ -65,7 +65,7 @@ func (s *TopicsService) GetMyTopics(ctx context.Context, spaceKey string) ([]*Fa
 
 // GetMyDirectMessageTopics fetches direct message topics list.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/2/get-dm-topics
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/2/get-dm-topics
 func (s *MessagesService) GetMyDirectMessageTopics(ctx context.Context, spaceKey string) ([]*DirectMessageTopic, *shared.Response, error) {
 	u, err := internal.AddQueries("messages", &getMyTopicsOptions{spaceKey})
 	if err != nil {

--- a/typetalk/v3/notifications.go
+++ b/typetalk/v3/notifications.go
@@ -30,7 +30,7 @@ type readNotificationOptions struct {
 
 // ReadNotification marks notifications as read.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/ja/docs/typetalk/api/3/open-notification
+// Typetalk API docs: https://developer.nulab.com/ja/docs/typetalk/api/3/open-notification
 func (s *NotificationsService) ReadNotification(ctx context.Context, spaceKey string) (*ReadNotificationResult, *shared.Response, error) {
 	u := "notifications"
 	var result *ReadNotificationResult

--- a/typetalk/v4/accounts.go
+++ b/typetalk/v4/accounts.go
@@ -50,7 +50,7 @@ type getMyFriendsOptions struct {
 
 // GetMyFriends searches accounts.
 //
-// https://developer.nulab-inc.com/docs/typetalk/api/4/get-friends
+// https://developer.nulab.com/docs/typetalk/api/4/get-friends
 func (s *AccountsService) GetMyFriends(ctx context.Context, spaceKey, q string, opt *GetMyFriendsOptions) (*Friends, *shared.Response, error) {
 	u, err := internal.AddQueries("search/friends", &getMyFriendsOptions{GetMyFriendsOptions: opt, SpaceKey: spaceKey, Q: q})
 	if err != nil {

--- a/typetalk/v5/notifications.go
+++ b/typetalk/v5/notifications.go
@@ -88,7 +88,7 @@ type Scheduled struct {
 
 // GetNotificationCount fetches notification counts.
 //
-// Typetalk API docs: https://developer.nulab-inc.com/docs/typetalk/api/5/get-notification-status/
+// Typetalk API docs: https://developer.nulab.com/docs/typetalk/api/5/get-notification-status/
 func (s *NotificationsService) GetNotificationCount(ctx context.Context) (*NotificationCount, *shared.Response, error) {
 	u := "notifications/status"
 	var result *NotificationCount


### PR DESCRIPTION
Typetalk API docs uses "nulab.com" domain now.