### PR TITLE
fix to support latest theme response

### DIFF
--- a/testdata/v1/get-my-profile.json
+++ b/testdata/v1/get-my-profile.json
@@ -12,7 +12,10 @@
       "updatedAt": "2018-10-29T03:01:43Z"
   },
   "lang": "en-US",
-  "theme": "light",
+  "theme": {
+    "source": "typetalk",
+    "name": "light"
+  },
   "post": {
       "useCtrl": false,
       "emojiSkinTone": "skin-tone-4"

--- a/typetalk/v1/accounts.go
+++ b/typetalk/v1/accounts.go
@@ -27,6 +27,12 @@ type Account struct {
 	ImageUpdatedAt *time.Time `json:"imageUpdatedAt"`
 }
 
+// Theme represents the appearance information used in Typetalk.
+type Theme struct {
+	Source string `json:"source"`
+	Name   string `json:"name"`
+}
+
 // Status represents online status of the user.
 type Status struct {
 	Presence *string     `json:"presence"`
@@ -47,7 +53,7 @@ type Profile AccountStatus
 type MyProfile struct {
 	Account *Account `json:"account"`
 	Lang    string   `json:"lang"`
-	Theme   string   `json:"theme"`
+	Theme   *Theme   `json:"theme"`
 	Post    *struct {
 		UseCtrl       bool   `json:"useCtrl"`
 		EmojiSkinTone string `json:"emojiSkinTone"`


### PR DESCRIPTION
The current Typetalk profile API returns an object instead of a string for the theme.